### PR TITLE
[#33] Extract GoRouter method to class and inject by GetIt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@
 
 ## Environment normalization:
 /.bundle/
-/vendor/bundle
+**/vendor/bundle
 /lib/bundler/man/
 
 # for a library or gem, you might want to ignore these files since the code is

--- a/integration_test/sign_in_screen_test.dart
+++ b/integration_test/sign_in_screen_test.dart
@@ -30,8 +30,9 @@ void signInTest() {
     testWidgets(
         "When the sign in screen shown, it displays the Sign In screen correctly",
         (WidgetTester tester) async {
-      await tester
-          .pumpWidget(TestUtil.pumpWidgetWithRoutePath(routePathSignInScreen));
+      await tester.pumpWidget(
+        TestUtil.pumpWidgetWithRoutePath(RoutePath.signIn.path),
+      );
 
       expect(emailField, findsOneWidget);
       expect(passwordField, findsOneWidget);
@@ -42,8 +43,9 @@ void signInTest() {
         "When sign in with valid email and password, it navigate to Home screen",
         (WidgetTester tester) async {
       await FakeData.initDefault();
-      await tester
-          .pumpWidget(TestUtil.pumpWidgetWithRoutePath(routePathSignInScreen));
+      await tester.pumpWidget(
+        TestUtil.pumpWidgetWithRoutePath(RoutePath.signIn.path),
+      );
       await tester.enterText(emailField, 'valid@example.com');
       await tester.enterText(passwordField, '1111111');
       await tester.tap(signInButton);

--- a/integration_test/utils/test_util.dart
+++ b/integration_test/utils/test_util.dart
@@ -32,13 +32,15 @@ class TestUtil {
   static Widget pumpWidgetWithRoutePath(String route) {
     _initDependencies();
 
+    final router = getIt.get<AppRouter>().router(route);
+
     return ProviderScope(
         child: MaterialApp.router(
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
-      routeInformationProvider: router(route).routeInformationProvider,
-      routeInformationParser: router(route).routeInformationParser,
-      routerDelegate: router(route).routerDelegate,
+      routeInformationProvider: router.routeInformationProvider,
+      routeInformationParser: router.routeInformationParser,
+      routerDelegate: router.routerDelegate,
     ));
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,15 +20,17 @@ class MyApp extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final router = getIt.get<AppRouter>().router();
+
     return AnnotatedRegion<SystemUiOverlayStyle>(
       value: SystemUiOverlayStyle.light,
       child: MaterialApp.router(
         theme: AppTheme.theme(AppColorScheme.light()),
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
-        routeInformationProvider: router().routeInformationProvider,
-        routeInformationParser: router().routeInformationParser,
-        routerDelegate: router().routerDelegate,
+        routeInformationProvider: router.routeInformationProvider,
+        routeInformationParser: router.routeInformationParser,
+        routerDelegate: router.routerDelegate,
       ),
     );
   }

--- a/lib/navigation/route.dart
+++ b/lib/navigation/route.dart
@@ -1,31 +1,40 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:injectable/injectable.dart';
 import 'package:survey_flutter_ic/ui/home/home_screen.dart';
 import 'package:survey_flutter_ic/ui/signin/sign_in_screen.dart';
 import 'package:survey_flutter_ic/ui/splash/splash_screen.dart';
 
-const routePathRootScreen = '/';
-const routePathHomeScreen = '/home';
-const routePathSignInScreen = '/sign_in';
+enum RoutePath {
+  root('/'),
+  home('/home'),
+  signIn('/sign_in');
 
-// TODO Extract to class and inject by GetIt
-GoRouter router([String? initialLocation]) => GoRouter(
-      initialLocation: initialLocation ?? routePathRootScreen,
-      routes: <GoRoute>[
-        GoRoute(
-          path: routePathRootScreen,
-          builder: (BuildContext context, GoRouterState state) =>
-              const SplashScreen(),
-        ),
-        GoRoute(
-          path: routePathSignInScreen,
-          builder: (BuildContext context, GoRouterState state) =>
-              const SignInScreen(),
-        ),
-        GoRoute(
-          path: routePathHomeScreen,
-          builder: (BuildContext context, GoRouterState state) =>
-              const HomeScreen(),
-        ),
-      ],
-    );
+  const RoutePath(this.path);
+
+  final String path;
+}
+
+@Singleton()
+class AppRouter {
+  GoRouter router([String? initialLocation]) => GoRouter(
+        initialLocation: initialLocation ?? RoutePath.root.path,
+        routes: <GoRoute>[
+          GoRoute(
+            path: RoutePath.root.path,
+            builder: (BuildContext context, GoRouterState state) =>
+                const SplashScreen(),
+          ),
+          GoRoute(
+            path: RoutePath.home.path,
+            builder: (BuildContext context, GoRouterState state) =>
+                const SignInScreen(),
+          ),
+          GoRoute(
+            path: RoutePath.signIn.path,
+            builder: (BuildContext context, GoRouterState state) =>
+                const HomeScreen(),
+          ),
+        ],
+      );
+}

--- a/lib/navigation/route.dart
+++ b/lib/navigation/route.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:injectable/injectable.dart';
 import 'package:survey_flutter_ic/ui/home/home_screen.dart';
@@ -6,13 +5,14 @@ import 'package:survey_flutter_ic/ui/signin/sign_in_screen.dart';
 import 'package:survey_flutter_ic/ui/splash/splash_screen.dart';
 
 enum RoutePath {
-  root('/'),
-  home('/home'),
-  signIn('/sign_in');
+  root('/', '/'),
+  home('/home', 'home'),
+  signIn('/sign_in', 'sign_in');
 
-  const RoutePath(this.path);
+  const RoutePath(this.path, this.name);
 
   final String path;
+  final String name;
 }
 
 @Singleton()
@@ -21,19 +21,19 @@ class AppRouter {
         initialLocation: initialLocation ?? RoutePath.root.path,
         routes: <GoRoute>[
           GoRoute(
+            name: RoutePath.root.name,
             path: RoutePath.root.path,
-            builder: (BuildContext context, GoRouterState state) =>
-                const SplashScreen(),
+            builder: (_, __) => const SplashScreen(),
           ),
           GoRoute(
+            name: RoutePath.home.name,
             path: RoutePath.home.path,
-            builder: (BuildContext context, GoRouterState state) =>
-                const SignInScreen(),
+            builder: (_, __) => const HomeScreen(),
           ),
           GoRoute(
+            name: RoutePath.signIn.name,
             path: RoutePath.signIn.path,
-            builder: (BuildContext context, GoRouterState state) =>
-                const HomeScreen(),
+            builder: (_, __) => const SignInScreen(),
           ),
         ],
       );

--- a/lib/ui/signin/sign_in_screen.dart
+++ b/lib/ui/signin/sign_in_screen.dart
@@ -22,7 +22,7 @@ class SignInScreen extends ConsumerWidget {
       state.maybeWhen(
           success: () => {
                 ref.read(_loadingStateProvider.notifier).state = false,
-                context.go(RoutePath.home.path)
+                context.goNamed(RoutePath.home.name)
               },
           loading: () {
             ref.read(_loadingStateProvider.notifier).state = true;

--- a/lib/ui/signin/sign_in_screen.dart
+++ b/lib/ui/signin/sign_in_screen.dart
@@ -22,7 +22,7 @@ class SignInScreen extends ConsumerWidget {
       state.maybeWhen(
           success: () => {
                 ref.read(_loadingStateProvider.notifier).state = false,
-                context.go(routePathHomeScreen)
+                context.go(RoutePath.home.path)
               },
           loading: () {
             ref.read(_loadingStateProvider.notifier).state = true;

--- a/lib/ui/splash/splash_screen.dart
+++ b/lib/ui/splash/splash_screen.dart
@@ -25,7 +25,7 @@ class _SplashScreenState extends State<SplashScreen> {
 
     Future.delayed(
         const Duration(milliseconds: _splashTransitionDelayInMilliseconds), () {
-      context.go(RoutePath.signIn.path);
+      context.goNamed(RoutePath.signIn.name);
     });
 
     Future.delayed(

--- a/lib/ui/splash/splash_screen.dart
+++ b/lib/ui/splash/splash_screen.dart
@@ -25,7 +25,7 @@ class _SplashScreenState extends State<SplashScreen> {
 
     Future.delayed(
         const Duration(milliseconds: _splashTransitionDelayInMilliseconds), () {
-      context.go(routePathSignInScreen);
+      context.go(RoutePath.signIn.path);
     });
 
     Future.delayed(


### PR DESCRIPTION
 https://github.com/Wadeewee/survey-flutter-ic-pooh/issues/33

## What happened 👀

We have a `TODO` to inject `GoRouter` with `GetIt`, but until we do that, we're experiencing issues with navigation. The navigation system does not navigate to the next screen:

https://github.com/Wadeewee/survey-flutter-ic-pooh/assets/28002315/1e680e69-8803-453b-bb67-2b75f9c4c42a

## Insight 📝

- Create an `AppRouter` class and enum `RoutePath` for the screen path.
- Inject `GoRouter` with `GetIt` in `main.dart` and `test_util.dart`

**Please note**: There's updating `.gitignore` for `/vendor/bundle` to `**/vendor/bundle` because the old one is not included `vendor` in the `ios` directory.

## Proof Of Work 📹

https://github.com/Wadeewee/survey-flutter-ic-pooh/assets/28002315/fe97fcba-6203-475a-9d07-0180ac20d553

