### PR TITLE
[Chore] Upgrade version fastlane to fix CD failed 

### DIFF
--- a/ios/Gemfile
+++ b/ios/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-gem "fastlane"
+gem "fastlane", "= 2.212.2"
 gem "cocoapods"

--- a/ios/Gemfile.lock
+++ b/ios/Gemfile.lock
@@ -17,7 +17,7 @@ GEM
     artifactory (3.0.15)
     atomos (0.1.3)
     aws-eventstream (1.2.0)
-    aws-partitions (1.761.0)
+    aws-partitions (1.762.0)
     aws-sdk-core (3.172.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.651.0)
@@ -116,7 +116,7 @@ GEM
     faraday_middleware (1.2.0)
       faraday (~> 1.0)
     fastimage (2.2.6)
-    fastlane (2.212.1)
+    fastlane (2.212.2)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.8, < 3.0.0)
       artifactory (~> 3.0)
@@ -279,7 +279,7 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods
-  fastlane (= 2.210.1)
+  fastlane (= 2.212.2)
 
 BUNDLED WITH
    2.3.10


### PR DESCRIPTION
https://github.com/Wadeewee/survey-flutter-ic-pooh/issues/36

## What happened 👀

The CD failed due to this error: https://github.com/Wadeewee/survey-flutter-ic-pooh/actions/runs/4946399035/jobs/8844411857

```yaml

[!] Error uploading ipa file: 
 [Application Loader Error Output]: Error uploading '/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/8cbdffbd-ec32-46af-83da-c8745dbe3a82.ipa'.
[Application Loader Error Output]: The provided entity includes an attribute with a value that has already been used The bundle version must be higher than the previously uploaded version: ‘85’. (ID: f7904dca-c665-4460-af60-73c322bed271) (-19232)
[Application Loader Error Output]: The call to the altool completed with a non-zero exit status: 1. This indicates a failure.
[09:48:47]: fastlane finished with errors

#######################################################################
# fastlane 2.212.2 is available. You are on 2.212.1.
# You should use the latest version.
# Please update using `bundle update fastlane`.
#######################################################################

2.212.2 Improvements and fix for some App Store Connect APIs
* [ci] Only run all mac jobs on master and version bump branches (#21088) via Josh Holtz (@joshdholtz)
* [spaceship] remove deprecated attributes from apps requests (#21187) via Kohki Miki (@giginet)
* [snapshot] fix resolve deadlock in LatestOsVersion#version_for_os (#20329) via stbix (@stbix)
* [deliver] Implements `verify` with `altool` for Xcode 14 validation (#20738) via Pol Piella Abadia (@polpielladev)
* [action][ensure_git_status_clean] fix incorrect "ignored" param handling (#20976) via Iulian Onofrei (@revolter)
* [spaceship] increase limit for build query in distribute to handle multiple platforms (#21087) via Eric Lindvall (@eric)

Please update using `bundle update fastlane`
Error: Process completed with exit code 1.
```

## Insight 📝

Upgrade version from ` 2.212.1` to `2.212.2` by running `bundle update fastlane`.

## Proof Of Work 📹

workflow: https://github.com/Wadeewee/survey-flutter-ic-pooh/actions/runs/4946999215/jobs/8845794886
