### PR TITLE
[#5] [Integrate] As a user, I can see the survey detail

### DIFF
--- a/integration_test/home_screen_test.dart
+++ b/integration_test/home_screen_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:survey_flutter_ic/navigation/route.dart';
 import 'package:survey_flutter_ic/ui/home/home_widget_id.dart';
+import 'package:survey_flutter_ic/ui/survey_detail/survey_detail_screen.dart';
 
 import 'fake_data/fake_data.dart';
 import 'utils/test_util.dart';
@@ -96,6 +97,20 @@ void homeScreenTest() {
       expect(titleText, findsNothing);
       expect(descriptionText, findsNothing);
       expect(nextButton, findsNothing);
+    });
+
+    testWidgets(
+        "When clicking on next button, it navigates to SurveyDetail screen",
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        TestUtil.pumpWidgetWithRoutePath(RoutePath.home.path),
+      );
+
+      await tester.pumpAndSettle();
+      await tester.tap(nextButton);
+
+      await tester.pumpAndSettle();
+      expect(find.byType(SurveyDetailScreen), findsOneWidget);
     });
   });
 }

--- a/integration_test/survey_detail_screen_test.dart
+++ b/integration_test/survey_detail_screen_test.dart
@@ -1,0 +1,113 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:survey_flutter_ic/model/survey_model.dart';
+import 'package:survey_flutter_ic/ui/home/home_screen.dart';
+import 'package:survey_flutter_ic/ui/survey_detail/survey_detail_widget_id.dart';
+
+import 'fake_data/fake_data.dart';
+import 'utils/test_util.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  surveyDetailScreenTest();
+}
+
+void surveyDetailScreenTest() {
+  group('SurveyDetail Page', () {
+    late Finder backButton;
+    late Finder coverImageUrl;
+    late Finder titleText;
+    late Finder descriptionText;
+    late Finder startSurveyButton;
+
+    const survey = SurveyModel(
+      id: '1',
+      title: 'Fake Survey Title',
+      description: 'Fake Survey Description',
+      isActive: true,
+      coverImageUrl:
+          'https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_',
+      largeCoverImageUrl:
+          'https://dhdbhh0jsld0o.cloudfront.net/m/1ea51560991bcb7d00d0_l',
+      createdAt: '2022-04-05T12:34:56Z',
+      surveyType: 'Fake Survey Type',
+    );
+
+    const surveyWithCoverImageEmpty = SurveyModel(
+      id: '1',
+      title: 'Fake Survey Title',
+      description: 'Fake Survey Description',
+      isActive: true,
+      coverImageUrl: '',
+      largeCoverImageUrl: '',
+      createdAt: '2022-04-05T12:34:56Z',
+      surveyType: 'Fake Survey Type',
+    );
+
+    setUpAll(() async {
+      await TestUtil.setupTestEnvironment();
+    });
+
+    setUp(() {
+      backButton = find.byKey(SurveyDetailWidgetId.backButton);
+      coverImageUrl = find.byKey(SurveyDetailWidgetId.coverImageUrl);
+      titleText = find.byKey(SurveyDetailWidgetId.titleText);
+      descriptionText = find.byKey(SurveyDetailWidgetId.descriptionText);
+      startSurveyButton = find.byKey(SurveyDetailWidgetId.startSurveyButton);
+    });
+
+    testWidgets(
+        "When setting survey successfully, it displays SurveyDetail screen correctly",
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        TestUtil.pumpWidgetWithRoutePath(
+          '/home/survey_detail',
+          extraBundle: survey,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(backButton, findsOneWidget);
+      expect(coverImageUrl, findsOneWidget);
+      expect(titleText, findsOneWidget);
+      expect(descriptionText, findsOneWidget);
+      expect(startSurveyButton, findsOneWidget);
+    });
+
+    testWidgets(
+        "When setting survey with CoverImageUrl is empty, it displays SurveyDetail screen correctly",
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        TestUtil.pumpWidgetWithRoutePath(
+          '/home/survey_detail',
+          extraBundle: surveyWithCoverImageEmpty,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(coverImageUrl, findsNothing);
+
+      expect(backButton, findsOneWidget);
+      expect(titleText, findsOneWidget);
+      expect(descriptionText, findsOneWidget);
+      expect(startSurveyButton, findsOneWidget);
+    });
+
+    testWidgets(
+        "When clicking on back button, it navigates back to Home screen",
+        (WidgetTester tester) async {
+      await FakeData.initDefault();
+      await tester.pumpWidget(
+        TestUtil.pumpWidgetWithRoutePath(
+          '/home/survey_detail',
+          extraBundle: survey,
+        ),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(backButton);
+
+      await tester.pumpAndSettle();
+      expect(find.byType(HomeScreen), findsOneWidget);
+    });
+  });
+}

--- a/integration_test/utils/test_util.dart
+++ b/integration_test/utils/test_util.dart
@@ -33,7 +33,7 @@ class TestUtil {
     );
   }
 
-  static Widget pumpWidgetWithRoutePath(String route, {dynamic extraBundle}) {
+  static Widget pumpWidgetWithRoutePath(String route, {Object? extraBundle}) {
     _initDependencies();
 
     final router = getIt.get<AppRouter>().router(route, extraBundle);

--- a/integration_test/utils/test_util.dart
+++ b/integration_test/utils/test_util.dart
@@ -33,10 +33,10 @@ class TestUtil {
     );
   }
 
-  static Widget pumpWidgetWithRoutePath(String route) {
+  static Widget pumpWidgetWithRoutePath(String route, {dynamic extraBundle}) {
     _initDependencies();
 
-    final router = getIt.get<AppRouter>().router(route);
+    final router = getIt.get<AppRouter>().router(route, extraBundle);
 
     return ProviderScope(
         child: MaterialApp.router(

--- a/lib/navigation/route.dart
+++ b/lib/navigation/route.dart
@@ -20,8 +20,13 @@ enum RoutePath {
 
 @Singleton()
 class AppRouter {
-  GoRouter router([String? initialLocation]) => GoRouter(
+  GoRouter router([
+    String? initialLocation,
+    dynamic extraBundle,
+  ]) =>
+      GoRouter(
         initialLocation: initialLocation ?? RoutePath.root.path,
+        initialExtra: extraBundle,
         routes: <GoRoute>[
           GoRoute(
             name: RoutePath.root.name,

--- a/lib/navigation/route.dart
+++ b/lib/navigation/route.dart
@@ -22,7 +22,7 @@ enum RoutePath {
 class AppRouter {
   GoRouter router([
     String? initialLocation,
-    dynamic extraBundle,
+    Object? extraBundle,
   ]) =>
       GoRouter(
         initialLocation: initialLocation ?? RoutePath.root.path,

--- a/lib/ui/survey_detail/survey_detail_screen.dart
+++ b/lib/ui/survey_detail/survey_detail_screen.dart
@@ -6,6 +6,8 @@ import 'package:survey_flutter_ic/extension/toast_extension.dart';
 import 'package:survey_flutter_ic/gen/assets.gen.dart';
 import 'package:survey_flutter_ic/model/survey_model.dart';
 import 'package:survey_flutter_ic/theme/dimens.dart';
+import 'package:survey_flutter_ic/ui/survey_detail/survey_detail_view_model.dart';
+import 'package:survey_flutter_ic/ui/survey_detail/survey_detail_widget_id.dart';
 import 'package:survey_flutter_ic/widget/flat_button_text.dart';
 
 class SurveyDetailScreen extends ConsumerStatefulWidget {
@@ -17,22 +19,25 @@ class SurveyDetailScreen extends ConsumerStatefulWidget {
   });
 
   @override
-  ConsumerState<SurveyDetailScreen> createState() => _SurveyDetailScreen();
+  ConsumerState<SurveyDetailScreen> createState() => _SurveyDetailState();
 }
 
-class _SurveyDetailScreen extends ConsumerState<SurveyDetailScreen> {
+class _SurveyDetailState extends ConsumerState<SurveyDetailScreen> {
+  @override
+  void initState() {
+    super.initState();
+    ref.read(surveyDetailViewModelProvider.notifier).setSurvey(widget.survey);
+  }
+
   @override
   Widget build(BuildContext context) {
+    final survey = ref.watch(surveyProvider).value;
+    final imageCoverUrl = survey?.largeCoverImageUrl ?? '';
+
     return Scaffold(
       body: Stack(
         children: [
-          Image.network(
-            // TODO: Binds data from ViewModel
-            widget.survey.largeCoverImageUrl,
-            fit: BoxFit.cover,
-            width: double.infinity,
-            height: double.infinity,
-          ),
+          if (imageCoverUrl.isNotEmpty) _buildCoverImageUrl(imageCoverUrl),
           SafeArea(
             child: Padding(
               padding: const EdgeInsets.all(space20),
@@ -41,9 +46,9 @@ class _SurveyDetailScreen extends ConsumerState<SurveyDetailScreen> {
                 children: [
                   _buildBackButton(),
                   const SizedBox(height: space30),
-                  _buildTitle(),
+                  _buildTitle(survey?.title ?? ''),
                   const SizedBox(height: space16),
-                  _buildDescription(),
+                  _buildDescription(survey?.description ?? ''),
                   const Expanded(child: SizedBox.shrink()),
                   _buildStartSurveyButton(),
                 ],
@@ -57,6 +62,7 @@ class _SurveyDetailScreen extends ConsumerState<SurveyDetailScreen> {
 
   Widget _buildBackButton() {
     return IconButton(
+      key: SurveyDetailWidgetId.backButton,
       icon: Assets.images.icArrowLeft.svg(),
       padding: EdgeInsets.zero,
       constraints: const BoxConstraints(),
@@ -64,10 +70,20 @@ class _SurveyDetailScreen extends ConsumerState<SurveyDetailScreen> {
     );
   }
 
-  Widget _buildTitle() {
+  Widget _buildCoverImageUrl(String imageCoverUrl) {
+    return Image.network(
+      key: SurveyDetailWidgetId.coverImageUrl,
+      imageCoverUrl,
+      fit: BoxFit.cover,
+      width: double.infinity,
+      height: double.infinity,
+    );
+  }
+
+  Widget _buildTitle(String title) {
     return Text(
-      // TODO: Binds data from ViewModel
-      widget.survey.title,
+      key: SurveyDetailWidgetId.titleText,
+      title,
       style: const TextStyle(
         color: Colors.white,
         fontSize: fontSize34,
@@ -76,10 +92,10 @@ class _SurveyDetailScreen extends ConsumerState<SurveyDetailScreen> {
     );
   }
 
-  Widget _buildDescription() {
+  Widget _buildDescription(String description) {
     return Text(
-      // TODO: Binds data from ViewModel
-      widget.survey.description,
+      key: SurveyDetailWidgetId.descriptionText,
+      description,
       overflow: TextOverflow.ellipsis,
       style: TextStyle(
         color: Colors.white.withOpacity(0.7),
@@ -91,6 +107,7 @@ class _SurveyDetailScreen extends ConsumerState<SurveyDetailScreen> {
 
   Widget _buildStartSurveyButton() {
     return Align(
+      key: SurveyDetailWidgetId.startSurveyButton,
       alignment: Alignment.bottomRight,
       child: FlatButtonText(
         text: context.localization.survey_detail_start_survey_button,

--- a/lib/ui/survey_detail/survey_detail_view_model.dart
+++ b/lib/ui/survey_detail/survey_detail_view_model.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:rxdart/rxdart.dart';
+import 'package:survey_flutter_ic/model/survey_model.dart';
+import 'package:survey_flutter_ic/ui/survey_detail/survey_detail_view_state.dart';
+
+final surveyDetailViewModelProvider = StateNotifierProvider.autoDispose<
+    SurveyDetailViewModel,
+    SurveyDetailViewState>((_) => SurveyDetailViewModel());
+
+final surveyProvider = StreamProvider.autoDispose(
+    (ref) => ref.watch(surveyDetailViewModelProvider.notifier).survey);
+
+class SurveyDetailViewModel extends StateNotifier<SurveyDetailViewState> {
+  SurveyDetailViewModel() : super(const SurveyDetailViewState.init());
+
+  final BehaviorSubject<SurveyModel> _survey = BehaviorSubject();
+
+  Stream<SurveyModel> get survey => _survey.stream;
+
+  void setSurvey(SurveyModel survey) {
+    _survey.add(survey);
+  }
+
+  @override
+  void dispose() async {
+    await _survey.close();
+    super.dispose();
+  }
+}

--- a/lib/ui/survey_detail/survey_detail_view_state.dart
+++ b/lib/ui/survey_detail/survey_detail_view_state.dart
@@ -1,0 +1,8 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'survey_detail_view_state.freezed.dart';
+
+@freezed
+class SurveyDetailViewState with _$SurveyDetailViewState {
+  const factory SurveyDetailViewState.init() = _Init;
+}

--- a/lib/ui/survey_detail/survey_detail_widget_id.dart
+++ b/lib/ui/survey_detail/survey_detail_widget_id.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+class SurveyDetailWidgetId {
+  SurveyDetailWidgetId._();
+
+  static const backButton = Key('backButton');
+  static const coverImageUrl = Key('coverImageUrl');
+  static const titleText = Key('titleText');
+  static const descriptionText = Key('descriptionText');
+  static const startSurveyButton = Key('startSurveyButton');
+}

--- a/test/ui/survey_detail/survey_detail_view_model_test.dart
+++ b/test/ui/survey_detail/survey_detail_view_model_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:survey_flutter_ic/model/survey_model.dart';
+import 'package:survey_flutter_ic/ui/survey_detail/survey_detail_view_model.dart';
+import 'package:survey_flutter_ic/ui/survey_detail/survey_detail_view_state.dart';
+
+void main() {
+  group('SurveyDetailViewModel', () {
+    late SurveyDetailViewModel viewModel;
+    late ProviderContainer container;
+
+    const survey = SurveyModel(
+      id: 'id',
+      title: 'title',
+      description: 'description',
+      isActive: true,
+      coverImageUrl: 'coverImageUrl',
+      largeCoverImageUrl: 'largeCoverImageUrl',
+      createdAt: 'createdAt',
+      surveyType: 'surveyType',
+    );
+
+    setUp(() {
+      container = ProviderContainer(overrides: [
+        surveyDetailViewModelProvider
+            .overrideWith((ref) => SurveyDetailViewModel())
+      ]);
+      viewModel = container.read(surveyDetailViewModelProvider.notifier);
+      addTearDown(() => container.dispose());
+    });
+
+    test('When initializing SurveyDetailViewModel, its state is Init', () {
+      expect(container.read(surveyDetailViewModelProvider),
+          const SurveyDetailViewState.init());
+    });
+
+    test('When setting survey, it emits survey', () {
+      expect(
+        viewModel.survey,
+        emitsThrough(survey),
+      );
+
+      container.read(surveyDetailViewModelProvider.notifier).setSurvey(survey);
+    });
+  });
+}


### PR DESCRIPTION
#5

## What happened 👀

- Upon tapping the Survey Disclosure button in Home, navigate the user to Survey Details with the selected survey.
    - Pass and use the selected survey data fetched in Home.
- Use the survey title as the Title label
- Use the survey description as the Description label
- Use the survey cover image URL as the background image

## Insight 📝

- Create `SurveyDetailViewModel`.
- Create `SurveyDetailViewModelTest`.
- Create `SurveyDetailScreenTest`.

## Proof Of Work 📹

- SurveyDetailScreen:

https://github.com/Wadeewee/survey-flutter-ic-pooh/assets/28002315/1794d523-4df0-4a0d-91e8-e432f727d6de

- SurveyDetailScreenTest:

https://github.com/Wadeewee/survey-flutter-ic-pooh/assets/28002315/20add761-ea2e-4ba9-8c1c-b39be1252435


