### PR TITLE
[#26] [Integrate] As a user, I can see pull to refresh the survey list

### DIFF
--- a/integration_test/home_screen_test.dart
+++ b/integration_test/home_screen_test.dart
@@ -41,6 +41,26 @@ void homeScreenTest() {
     });
 
     testWidgets(
+        "When loading data and getSurveys failed, it displays Home screen correctly",
+        (WidgetTester tester) async {
+      FakeData.updateResponse(keySurveys, const FakeResponseModel(400, {}));
+      await tester.pumpWidget(
+        TestUtil.pumpWidgetWithRoutePath(RoutePath.home.path),
+      );
+      await tester.pumpAndSettle();
+
+      expect(profileAvatar, findsOneWidget);
+      expect(dateText, findsOneWidget);
+      expect(todayText, findsOneWidget);
+
+      expect(pagerIndicator, findsNothing);
+      expect(coverImageUrl, findsNothing);
+      expect(titleText, findsNothing);
+      expect(descriptionText, findsNothing);
+      expect(nextButton, findsNothing);
+    });
+
+    testWidgets(
         "When loading data successfully, it displays Home screen correctly",
         (WidgetTester tester) async {
       await tester.pumpWidget(
@@ -77,26 +97,6 @@ void homeScreenTest() {
       expect(titleText, findsOneWidget);
       expect(descriptionText, findsOneWidget);
       expect(nextButton, findsOneWidget);
-    });
-
-    testWidgets(
-        "When loading data and getSurveys failed, it displays Home screen correctly",
-        (WidgetTester tester) async {
-      FakeData.updateResponse(keySurveys, const FakeResponseModel(400, {}));
-      await tester.pumpWidget(
-        TestUtil.pumpWidgetWithRoutePath(RoutePath.home.path),
-      );
-      await tester.pumpAndSettle();
-
-      expect(profileAvatar, findsOneWidget);
-      expect(dateText, findsOneWidget);
-      expect(todayText, findsOneWidget);
-
-      expect(pagerIndicator, findsNothing);
-      expect(coverImageUrl, findsNothing);
-      expect(titleText, findsNothing);
-      expect(descriptionText, findsNothing);
-      expect(nextButton, findsNothing);
     });
 
     testWidgets(

--- a/integration_test/utils/test_util.dart
+++ b/integration_test/utils/test_util.dart
@@ -6,6 +6,7 @@ import 'package:package_info_plus/package_info_plus.dart';
 import 'package:survey_flutter_ic/api/service/auth_service.dart';
 import 'package:survey_flutter_ic/api/service/survey_service.dart';
 import 'package:survey_flutter_ic/api/service/user_service.dart';
+import 'package:survey_flutter_ic/database/persistence/hive_persistence.dart';
 import 'package:survey_flutter_ic/di/provider/di.dart';
 import 'package:survey_flutter_ic/main.dart';
 import 'package:survey_flutter_ic/navigation/route.dart';
@@ -66,7 +67,8 @@ class TestUtil {
 
   static Future setupTestEnvironment() async {
     _initDependencies();
-    configureInjection();
+    await initHivePersistence();
+    await configureInjection();
 
     getIt.allowReassignment = true;
     getIt.registerSingleton<AuthService>(FakeAuthService());

--- a/lib/di/provider/di.dart
+++ b/lib/di/provider/di.dart
@@ -10,4 +10,4 @@ final getIt = GetIt.instance;
   preferRelativeImports: true,
   asExtension: false,
 )
-void configureInjection() => $initGetIt(getIt);
+Future<void> configureInjection() => $initGetIt(getIt);

--- a/lib/ui/home/home_screen.dart
+++ b/lib/ui/home/home_screen.dart
@@ -61,37 +61,55 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     List<SurveyModel> surveys,
   ) {
     return Scaffold(
-      body: Stack(
-        children: [
-          PageView.builder(
-            controller: _pageController,
-            onPageChanged: (index) {
-              setState(() {
-                _currentIndex = index;
-              });
-            },
-            itemCount: surveys.length,
-            itemBuilder: (_, index) {
-              return HomeSurveyItem(
-                survey: surveys[index],
-                onNextButtonPressed: () {
-                  context.goNamed(
-                    RoutePath.surveyDetail.name,
-                    extra: surveys[_currentIndex],
-                  );
-                },
-              );
-            },
-          ),
-          SafeArea(
-            child: HomeHeader(
-              date: today,
-              avatar: profileAvatar,
+      body: RefreshIndicator(
+        color: Colors.white,
+        backgroundColor: Colors.white30,
+        onRefresh: () {
+          _currentIndex = 0;
+          return ref
+              .read(homeViewModelProvider.notifier)
+              .loadData(isRefresh: true);
+        },
+        child: Stack(
+          children: [
+            _buildPagerView(surveys),
+            SafeArea(
+              child: HomeHeader(
+                date: today,
+                avatar: profileAvatar,
+              ),
             ),
-          ),
-          if (surveys.isNotEmpty) _buildPagerIndicator(surveys)
-        ],
+            ListView(
+              shrinkWrap: true,
+              physics: const AlwaysScrollableScrollPhysics(),
+            ),
+            if (surveys.isNotEmpty) _buildPagerIndicator(surveys)
+          ],
+        ),
       ),
+    );
+  }
+
+  Widget _buildPagerView(List<SurveyModel> surveys) {
+    return PageView.builder(
+      controller: _pageController,
+      onPageChanged: (index) {
+        setState(() {
+          _currentIndex = index;
+        });
+      },
+      itemCount: surveys.length,
+      itemBuilder: (_, index) {
+        return HomeSurveyItem(
+          survey: surveys[index],
+          onNextButtonPressed: () {
+            context.goNamed(
+              RoutePath.surveyDetail.name,
+              extra: surveys[_currentIndex],
+            );
+          },
+        );
+      },
     );
   }
 

--- a/test/mocks/generate_mocks.dart
+++ b/test/mocks/generate_mocks.dart
@@ -11,6 +11,7 @@ import 'package:survey_flutter_ic/api/service/survey_service.dart';
 import 'package:survey_flutter_ic/api/service/user_service.dart';
 import 'package:survey_flutter_ic/database/persistence/survey_persistence.dart';
 import 'package:survey_flutter_ic/usecase/get_and_cache_surveys_use_case.dart';
+import 'package:survey_flutter_ic/usecase/get_cached_surveys_use_case.dart';
 import 'package:survey_flutter_ic/usecase/get_profile_use_case.dart';
 import 'package:survey_flutter_ic/usecase/sign_in_use_case.dart';
 
@@ -23,6 +24,7 @@ import 'package:survey_flutter_ic/usecase/sign_in_use_case.dart';
   SurveyService,
   SurveyRepository,
   GetAndCacheSurveysUseCase,
+  GetCachedSurveysUseCase,
   UserService,
   UserRepository,
   GetProfileUseCase,


### PR DESCRIPTION
 #26

## What happened 👀

On the home screen, when the user swipes from top to bottom, the application must fetch the latest surveys and refresh the survey list.
- Support pull-down to refresh the list of surveys.
- Refresh data from API.
- Show a loading indicator (implemented) while doing the refreshing.

## Insight 📝

- Use `RefreshIndicator` as the parent widget of the body in the HomeScreen.
- When entering the HomeScreen, we will call `getCachedSurveys` from the `database` to retrieve survey data. If the result is `empty`, then call `getSurveys` from the `API`.
- Whenever the user performs a `Pull to refresh` action, call `getSurveys` from the `API`.

## Proof Of Work 📹


https://github.com/Wadeewee/survey-flutter-ic-pooh/assets/28002315/e82b4c5f-dd39-4821-83a1-2bc0e6274f4f

