### PR TITLE
[20] [Integrate] As a user, I can see Home screen when signed-in

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,7 +13,7 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await FlutterConfig.loadEnvVariables();
   await initHivePersistence();
-  configureInjection();
+  await configureInjection();
   runApp(const ProviderScope(child: MyApp()));
 }
 

--- a/lib/ui/home/home_screen.dart
+++ b/lib/ui/home/home_screen.dart
@@ -79,9 +79,9 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
                 avatar: profileAvatar,
               ),
             ),
-            ListView(
-              shrinkWrap: true,
-              physics: const AlwaysScrollableScrollPhysics(),
+            FractionallySizedBox(
+              heightFactor: 0.3,
+              child: ListView(),
             ),
             if (surveys.isNotEmpty) _buildPagerIndicator(surveys)
           ],

--- a/lib/ui/splash/splash_screen.dart
+++ b/lib/ui/splash/splash_screen.dart
@@ -1,45 +1,44 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:survey_flutter_ic/gen/assets.gen.dart';
 import 'package:survey_flutter_ic/navigation/route.dart';
+import 'package:survey_flutter_ic/ui/splash/splash_view_model.dart';
 
-const _splashTransitionDelayInMilliseconds = 2000;
 const _logoVisibilityDelayInMilliseconds = 500;
 const _logoVisibilityAnimationInMilliseconds = 1000;
 
-class SplashScreen extends StatefulWidget {
+class SplashScreen extends ConsumerStatefulWidget {
   const SplashScreen({Key? key}) : super(key: key);
 
   @override
-  State<SplashScreen> createState() => _SplashScreenState();
+  ConsumerState<SplashScreen> createState() => _SplashScreenState();
 }
 
-class _SplashScreenState extends State<SplashScreen> {
+class _SplashScreenState extends ConsumerState<SplashScreen> {
   bool _logoVisible = false;
 
   @override
   void initState() {
+    super.initState();
+
     SystemChrome.setSystemUIOverlayStyle(
         const SystemUiOverlayStyle(statusBarColor: Colors.transparent));
 
     Future.delayed(
-        const Duration(milliseconds: _splashTransitionDelayInMilliseconds), () {
-      context.goNamed(RoutePath.signIn.name);
-    });
-
-    Future.delayed(
         const Duration(milliseconds: _logoVisibilityDelayInMilliseconds), () {
       setState(() {
+        ref.read(splashViewModelProvider.notifier).checkIsAuthorized();
         _logoVisible = true;
       });
     });
-
-    super.initState();
   }
 
   @override
   Widget build(BuildContext context) {
+    final isAuthorized = ref.watch(isAuthorizedProvider).value ?? false;
+
     return Scaffold(
       body: Container(
         decoration: BoxDecoration(
@@ -52,6 +51,13 @@ class _SplashScreenState extends State<SplashScreen> {
                 milliseconds: _logoVisibilityAnimationInMilliseconds),
             opacity: _logoVisible ? 1.0 : 0.0,
             child: Assets.images.icLogo.svg(),
+            onEnd: () {
+              if (isAuthorized) {
+                context.goNamed(RoutePath.home.name);
+              } else {
+                context.goNamed(RoutePath.signIn.name);
+              }
+            },
           ),
         ),
       ),

--- a/lib/ui/splash/splash_view_model.dart
+++ b/lib/ui/splash/splash_view_model.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:rxdart/rxdart.dart';
+import 'package:survey_flutter_ic/di/provider/di.dart';
+import 'package:survey_flutter_ic/ui/splash/splash_view_state.dart';
+import 'package:survey_flutter_ic/usecase/base/base_use_case.dart';
+import 'package:survey_flutter_ic/usecase/is_authorized_use_case.dart';
+
+final splashViewModelProvider =
+    StateNotifierProvider.autoDispose<SplashViewModel, SplashViewState>(
+        (_) => SplashViewModel(
+              getIt.get<IsAuthorizedUseCase>(),
+            ));
+
+final isAuthorizedProvider = StreamProvider.autoDispose(
+    (ref) => ref.watch(splashViewModelProvider.notifier).isAuthorized);
+
+class SplashViewModel extends StateNotifier<SplashViewState> {
+  final IsAuthorizedUseCase _isAuthorizedUseCase;
+
+  SplashViewModel(this._isAuthorizedUseCase)
+      : super(const SplashViewState.init());
+
+  final BehaviorSubject<bool> _isAuthorized = BehaviorSubject();
+
+  Stream<bool> get isAuthorized => _isAuthorized.stream;
+
+  Future checkIsAuthorized() async {
+    _isAuthorizedUseCase.call().asStream().listen((result) {
+      final isAuthorized = (result as Success<bool>).value;
+      _isAuthorized.add(isAuthorized);
+    });
+  }
+
+  @override
+  void dispose() async {
+    await _isAuthorized.close();
+    super.dispose();
+  }
+}

--- a/lib/ui/splash/splash_view_state.dart
+++ b/lib/ui/splash/splash_view_state.dart
@@ -1,0 +1,8 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'splash_view_state.freezed.dart';
+
+@freezed
+class SplashViewState with _$SplashViewState {
+  const factory SplashViewState.init() = _Init;
+}

--- a/lib/usecase/is_authorized_use_case.dart
+++ b/lib/usecase/is_authorized_use_case.dart
@@ -1,0 +1,19 @@
+import 'dart:async';
+
+import 'package:injectable/injectable.dart';
+import 'package:survey_flutter_ic/api/persistence/auth_persistence.dart';
+import 'package:survey_flutter_ic/usecase/base/base_use_case.dart';
+
+@Injectable()
+class IsAuthorizedUseCase extends NoParamsUseCase<bool> {
+  final AuthPersistence _persistence;
+
+  const IsAuthorizedUseCase(this._persistence);
+
+  @override
+  Future<Result<bool>> call() async {
+    final isAuthorized = await _persistence.accessToken != null;
+
+    return Success(isAuthorized);
+  }
+}

--- a/test/mocks/generate_mocks.dart
+++ b/test/mocks/generate_mocks.dart
@@ -12,6 +12,7 @@ import 'package:survey_flutter_ic/database/persistence/survey_persistence.dart';
 import 'package:survey_flutter_ic/usecase/get_and_cache_surveys_use_case.dart';
 import 'package:survey_flutter_ic/usecase/get_cached_surveys_use_case.dart';
 import 'package:survey_flutter_ic/usecase/get_profile_use_case.dart';
+import 'package:survey_flutter_ic/usecase/is_authorized_use_case.dart';
 import 'package:survey_flutter_ic/usecase/sign_in_use_case.dart';
 
 @GenerateMocks([
@@ -29,6 +30,7 @@ import 'package:survey_flutter_ic/usecase/sign_in_use_case.dart';
   DioError,
   SurveyPersistence,
   Box,
+  IsAuthorizedUseCase,
 ])
 main() {
   // empty class to generate mock repository classes

--- a/test/ui/splash/splash_view_model_test.dart
+++ b/test/ui/splash/splash_view_model_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:survey_flutter_ic/ui/splash/splash_view_model.dart';
+import 'package:survey_flutter_ic/ui/splash/splash_view_state.dart';
+import 'package:survey_flutter_ic/usecase/base/base_use_case.dart';
+
+import '../../mocks/generate_mocks.mocks.dart';
+
+void main() {
+  group('SplashViewModel', () {
+    late MockIsAuthorizedUseCase mockIsAuthorizedUseCase;
+    late SplashViewModel viewModel;
+    late ProviderContainer container;
+
+    setUp(() {
+      mockIsAuthorizedUseCase = MockIsAuthorizedUseCase();
+      container = ProviderContainer(overrides: [
+        splashViewModelProvider
+            .overrideWith((ref) => SplashViewModel(mockIsAuthorizedUseCase))
+      ]);
+      viewModel = container.read(splashViewModelProvider.notifier);
+      addTearDown(() => container.dispose());
+    });
+
+    test('When initializing SplashViewModel, its state is Init', () {
+      expect(container.read(splashViewModelProvider),
+          const SplashViewState.init());
+    });
+
+    test(
+        'When calling CheckIsAuthorized successfully with result is true, it emits isAuthorized with true',
+        () {
+      when(mockIsAuthorizedUseCase.call())
+          .thenAnswer((_) async => Success(true));
+
+      expect(
+        viewModel.isAuthorized,
+        emitsThrough(true),
+      );
+
+      container.read(splashViewModelProvider.notifier).checkIsAuthorized();
+    });
+
+    test(
+        'When calling CheckIsAuthorized successfully with result is false, it emits isAuthorized with false',
+        () {
+      when(mockIsAuthorizedUseCase.call())
+          .thenAnswer((_) async => Success(false));
+
+      expect(
+        viewModel.isAuthorized,
+        emitsThrough(false),
+      );
+
+      container.read(splashViewModelProvider.notifier).checkIsAuthorized();
+    });
+  });
+}

--- a/test/usecase/is_authorized_use_case_test.dart
+++ b/test/usecase/is_authorized_use_case_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:survey_flutter_ic/usecase/base/base_use_case.dart';
+import 'package:survey_flutter_ic/usecase/is_authorized_use_case.dart';
+
+import '../mocks/generate_mocks.mocks.dart';
+
+void main() {
+  group('IsAuthorizedUseCase', () {
+    late MockAuthPersistence mockPersistence;
+    late IsAuthorizedUseCase useCase;
+
+    setUp(() {
+      mockPersistence = MockAuthPersistence();
+      useCase = IsAuthorizedUseCase(mockPersistence);
+    });
+
+    test(
+        'When calling IsAuthorizedUseCase with result is true, it returns the result Success with true',
+        () async {
+      when(mockPersistence.accessToken).thenAnswer((_) async => 'accessToken');
+
+      final result = await useCase.call();
+
+      expect(result, isA<Success>());
+      expect((result as Success).value, true);
+    });
+
+    test(
+        'When calling IsAuthorizedUseCase with result is false, it returns the result Success with false',
+        () async {
+      when(mockPersistence.accessToken).thenAnswer((_) async => null);
+
+      final result = await useCase.call();
+
+      expect(result, isA<Success>());
+      expect((result as Success).value, false);
+    });
+  });
+}


### PR DESCRIPTION
#20

## What happened 👀

Redirect user to Home screen if already signed in

## Insight 📝

- Create `IsAuthorizedUseCase`.
- Create `SplashViewModel`.
- When entering the `SplahScreen`, we will check if the user is signed in:
   - If yes -> navigate to `HomeScreen`.
   - If not -> navigate to `SingInScreen`.
- Fix `PullRefreshIndicator` is not working on Android by using `FractionallySizedBox` and define at least `heightFactor` at `0.3`

## Proof Of Work 📹

- If `signed in`, navigate to `HomeScreen`.

https://github.com/Wadeewee/survey-flutter-ic-pooh/assets/28002315/8fbf17b2-75ca-4815-af77-bf67d6212e11

-  If not `signed in`, navigate to `SingInScreen`.

https://github.com/Wadeewee/survey-flutter-ic-pooh/assets/28002315/805806fe-43e6-4fee-8888-c095d672f033


- Fix `PullRefreshIndicator` on `Android`.

https://github.com/Wadeewee/survey-flutter-ic-pooh/assets/28002315/1b45a309-7ba1-4585-a3c2-e548c89f0d13

