### PR TITLE
[#9] [UI] As a user, I can see the survey questions

### DIFF
--- a/assets/images/ic_close.svg
+++ b/assets/images/ic_close.svg
@@ -1,0 +1,21 @@
+<svg width="28" height="28" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path opacity="0.2" fill-rule="evenodd" clip-rule="evenodd"
+        d="M14 28C21.732 28 28 21.732 28 14C28 6.26801 21.732 0 14 0C6.26801 0 0 6.26801 0 14C0 21.732 6.26801 28 14 28Z"
+        fill="white" />
+    <g filter="url(#filter0_b_13330_949)">
+        <path fill-rule="evenodd" clip-rule="evenodd"
+            d="M8.85518 8.85518C8.38161 9.32874 8.38161 10.0965 8.85518 10.5701L12.2851 14L8.85518 17.4299C8.38161 17.9035 8.38161 18.6713 8.85518 19.1448C9.32874 19.6184 10.0965 19.6184 10.5701 19.1448L14 15.7149L17.4299 19.1448C17.9035 19.6184 18.6713 19.6184 19.1448 19.1448C19.6184 18.6713 19.6184 17.9035 19.1448 17.4299L15.7149 14L19.1448 10.5701C19.6184 10.0965 19.6184 9.32874 19.1448 8.85518C18.6713 8.38161 17.9035 8.38161 17.4299 8.85518L14 12.2851L10.5701 8.85518C10.0965 8.38161 9.32874 8.38161 8.85518 8.85518Z"
+            fill="white" fill-opacity="0.92" />
+    </g>
+    <defs>
+        <filter id="filter0_b_13330_949" x="-18.6828" y="-18.6828" width="65.3656" height="65.3656"
+            filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+            <feFlood flood-opacity="0" result="BackgroundImageFix" />
+            <feGaussianBlur in="BackgroundImageFix" stdDeviation="13.5914" />
+            <feComposite in2="SourceAlpha" operator="in"
+                result="effect1_backgroundBlur_13330_949" />
+            <feBlend mode="normal" in="SourceGraphic" in2="effect1_backgroundBlur_13330_949"
+                result="shape" />
+        </filter>
+    </defs>
+</svg>

--- a/lib/navigation/route.dart
+++ b/lib/navigation/route.dart
@@ -5,12 +5,16 @@ import 'package:survey_flutter_ic/ui/home/home_screen.dart';
 import 'package:survey_flutter_ic/ui/signin/sign_in_screen.dart';
 import 'package:survey_flutter_ic/ui/splash/splash_screen.dart';
 import 'package:survey_flutter_ic/ui/survey_detail/survey_detail_screen.dart';
+import 'package:survey_flutter_ic/ui/survey_question/survey_questions_screen.dart';
+
+const surveyIdKey = 'surveyId';
 
 enum RoutePath {
   root('/', '/'),
   home('/home', 'home'),
   signIn('/sign_in', 'sign_in'),
-  surveyDetail('survey_detail', 'survey_detail');
+  surveyDetail('survey_detail', 'survey_detail'),
+  surveyQuestions('survey_questions/:$surveyIdKey', 'survey_questions');
 
   const RoutePath(this.path, this.name);
 
@@ -48,6 +52,13 @@ class AppRouter {
                 path: RoutePath.surveyDetail.path,
                 builder: (_, state) => SurveyDetailScreen(
                   survey: (state.extra as SurveyModel),
+                ),
+              ),
+              GoRoute(
+                name: RoutePath.surveyQuestions.name,
+                path: RoutePath.surveyQuestions.path,
+                builder: (_, state) => SurveyQuestionsScreen(
+                  surveyId: (state.params[surveyIdKey] as String),
                 ),
               ),
             ],

--- a/lib/ui/survey_detail/survey_detail_screen.dart
+++ b/lib/ui/survey_detail/survey_detail_screen.dart
@@ -2,9 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:survey_flutter_ic/extension/context_extension.dart';
-import 'package:survey_flutter_ic/extension/toast_extension.dart';
 import 'package:survey_flutter_ic/gen/assets.gen.dart';
 import 'package:survey_flutter_ic/model/survey_model.dart';
+import 'package:survey_flutter_ic/navigation/route.dart';
 import 'package:survey_flutter_ic/theme/dimens.dart';
 import 'package:survey_flutter_ic/ui/survey_detail/survey_detail_view_model.dart';
 import 'package:survey_flutter_ic/ui/survey_detail/survey_detail_widget_id.dart';
@@ -50,7 +50,7 @@ class _SurveyDetailState extends ConsumerState<SurveyDetailScreen> {
                   const SizedBox(height: space16),
                   _buildDescription(survey?.description ?? ''),
                   const Expanded(child: SizedBox.shrink()),
-                  _buildStartSurveyButton(),
+                  _buildStartSurveyButton(survey?.id ?? ''),
                 ],
               ),
             ),
@@ -96,7 +96,6 @@ class _SurveyDetailState extends ConsumerState<SurveyDetailScreen> {
     return Text(
       key: SurveyDetailWidgetId.descriptionText,
       description,
-      overflow: TextOverflow.ellipsis,
       style: TextStyle(
         color: Colors.white.withOpacity(0.7),
         fontSize: fontSize17,
@@ -105,17 +104,17 @@ class _SurveyDetailState extends ConsumerState<SurveyDetailScreen> {
     );
   }
 
-  Widget _buildStartSurveyButton() {
+  Widget _buildStartSurveyButton(String id) {
     return Align(
       key: SurveyDetailWidgetId.startSurveyButton,
       alignment: Alignment.bottomRight,
       child: FlatButtonText(
         text: context.localization.survey_detail_start_survey_button,
         isEnabled: true,
-        onPressed: () {
-          // TODO: Navigate to question screen
-          showToastMessage("Start Survey");
-        },
+        onPressed: () => context.goNamed(
+          RoutePath.surveyQuestions.name,
+          params: {surveyIdKey: id},
+        ),
       ),
     );
   }

--- a/lib/ui/survey_question/survey_questions_screen.dart
+++ b/lib/ui/survey_question/survey_questions_screen.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:survey_flutter_ic/extension/toast_extension.dart';
+import 'package:survey_flutter_ic/gen/assets.gen.dart';
+import 'package:survey_flutter_ic/theme/dimens.dart';
+import 'package:survey_flutter_ic/widget/circle_next_button.dart';
+
+class SurveyQuestionsScreen extends ConsumerStatefulWidget {
+  final String surveyId;
+
+  const SurveyQuestionsScreen({
+    super.key,
+    required this.surveyId,
+  });
+
+  @override
+  ConsumerState<SurveyQuestionsScreen> createState() => _SurveyQuestionsState();
+}
+
+class _SurveyQuestionsState extends ConsumerState<SurveyQuestionsScreen> {
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Stack(
+        children: [
+          _buildCoverImageUrl(),
+          SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.all(space20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildCloseButton(),
+                  const SizedBox(height: space30),
+                  _buildQuestionsIndicator(),
+                  const SizedBox(height: space10),
+                  _buildQuestionLabel(),
+                  const Expanded(child: SizedBox.shrink()),
+                  _buildNextButton(),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildCloseButton() {
+    return Align(
+      alignment: Alignment.topRight,
+      child: IconButton(
+        icon: Assets.images.icClose.svg(),
+        padding: EdgeInsets.zero,
+        constraints: const BoxConstraints(),
+        onPressed: () => context.pop(),
+      ),
+    );
+  }
+
+  Widget _buildCoverImageUrl() {
+    return Image.network(
+      // TODO: Bind data from VM.
+      "https://i.postimg.cc/NjT59j53/Background-3x.jpg",
+      fit: BoxFit.cover,
+      width: double.infinity,
+      height: double.infinity,
+    );
+  }
+
+  Widget _buildQuestionsIndicator() {
+    return Text(
+      // TODO: Bind data from VM.
+      "1/5",
+      style: TextStyle(
+        color: Colors.white.withOpacity(0.7),
+        fontSize: fontSize17,
+        fontWeight: FontWeight.w400,
+      ),
+    );
+  }
+
+  Widget _buildQuestionLabel() {
+    return const Text(
+      // TODO: Bind data from VM.
+      "How fulfilled did you fell during this WFH period?",
+      style: TextStyle(
+        color: Colors.white,
+        fontSize: fontSize34,
+        fontWeight: FontWeight.w800,
+      ),
+    );
+  }
+
+  Widget _buildNextButton() {
+    return Align(
+      alignment: Alignment.bottomRight,
+      child: CircleNextButton(
+        onPressed: () {
+          // TODO: Show the next question
+          showToastMessage("Next question");
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
#9

## What happened 👀

- Display the background image
- Display the Dismiss button
    - Tapping the Dismiss button should navigate the user to the previous screen
- Display the Question Number label (Above the Question label)
- Display the Question label
- Display the Next button
- **DO NOT** display the Answer section yet.
    - There are many types of answers. There will be separate tickets to handle them.

## Insight 📝

- Add `surveyQuestions` route.
- Create `SurveyQuestionsScreen`.

## Proof Of Work 📹

https://github.com/Wadeewee/survey-flutter-ic-pooh/assets/28002315/8aec67e4-e1e8-439b-8e3d-e0c0b22eaff5


