### PR TITLE
[#54] [Chore] Integration Test SplashScreen

### DIFF
--- a/integration_test/splash_screen_test.dart
+++ b/integration_test/splash_screen_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:survey_flutter_ic/navigation/route.dart';
+import 'package:survey_flutter_ic/ui/home/home_screen.dart';
+import 'package:survey_flutter_ic/ui/signin/sign_in_screen.dart';
+import 'package:survey_flutter_ic/ui/splash/splash_widget_id.dart';
+
+import 'fake_data/fake_data.dart';
+import 'utils/test_util.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  splashScreenTest();
+}
+
+void splashScreenTest() {
+  group('Splash Page', () {
+    late Finder background;
+    late Finder logo;
+
+    setUpAll(() async {
+      await TestUtil.setupTestEnvironment();
+    });
+
+    setUp(() {
+      background = find.byKey(SplashWidgetId.background);
+      logo = find.byKey(SplashWidgetId.logo);
+    });
+
+    testWidgets(
+        "When entering SplashScreen with signed-in, it navigates to Home screen",
+        (WidgetTester tester) async {
+      FlutterSecureStorage.setMockInitialValues({
+        'KEY_ACCESS_TOKEN': 'accessToken',
+      });
+      await FakeData.initDefault();
+      await tester.pumpWidget(
+        TestUtil.pumpWidgetWithRoutePath(RoutePath.root.path),
+      );
+
+      await tester.pumpAndSettle();
+      expect(background, findsOneWidget);
+
+      await tester.pump(const Duration(milliseconds: 500));
+      expect(logo, findsOneWidget);
+
+      await tester.pumpAndSettle();
+      expect(find.byType(HomeScreen), findsOneWidget);
+    });
+
+    testWidgets(
+        "When entering SplashScreen with not signed-in, it navigates to SignIn screen",
+        (WidgetTester tester) async {
+      FlutterSecureStorage.setMockInitialValues({'KEY_ACCESS_TOKEN': ''});
+      await tester.pumpWidget(
+        TestUtil.pumpWidgetWithRoutePath(RoutePath.root.path),
+      );
+
+      await tester.pumpAndSettle();
+      expect(background, findsOneWidget);
+
+      await tester.pump(const Duration(milliseconds: 500));
+      expect(logo, findsOneWidget);
+
+      await tester.pumpAndSettle();
+      expect(find.byType(SignInScreen), findsOneWidget);
+    });
+  });
+}

--- a/lib/api/persistence/auth_persistence.dart
+++ b/lib/api/persistence/auth_persistence.dart
@@ -21,7 +21,7 @@ abstract class AuthPersistence {
   Future<void> clearAllStorage();
 }
 
-@Singleton(as: AuthPersistence)
+@LazySingleton(as: AuthPersistence)
 class AuthPersistenceImpl extends AuthPersistence {
   final FlutterSecureStorage _storage;
 

--- a/lib/ui/splash/splash_screen.dart
+++ b/lib/ui/splash/splash_screen.dart
@@ -5,6 +5,7 @@ import 'package:go_router/go_router.dart';
 import 'package:survey_flutter_ic/gen/assets.gen.dart';
 import 'package:survey_flutter_ic/navigation/route.dart';
 import 'package:survey_flutter_ic/ui/splash/splash_view_model.dart';
+import 'package:survey_flutter_ic/ui/splash/splash_widget_id.dart';
 
 const _logoVisibilityDelayInMilliseconds = 500;
 const _logoVisibilityAnimationInMilliseconds = 1000;
@@ -41,11 +42,13 @@ class _SplashScreenState extends ConsumerState<SplashScreen> {
 
     return Scaffold(
       body: Container(
+        key: SplashWidgetId.background,
         decoration: BoxDecoration(
           image: DecorationImage(
               image: AssetImage(Assets.images.bgSplash.path), fit: BoxFit.fill),
         ),
         child: Center(
+          key: SplashWidgetId.logo,
           child: AnimatedOpacity(
             duration: const Duration(
                 milliseconds: _logoVisibilityAnimationInMilliseconds),

--- a/lib/ui/splash/splash_widget_id.dart
+++ b/lib/ui/splash/splash_widget_id.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/material.dart';
+
+class SplashWidgetId {
+  SplashWidgetId._();
+
+  static const background = Key('background');
+  static const logo = Key('logo');
+}

--- a/lib/usecase/is_authorized_use_case.dart
+++ b/lib/usecase/is_authorized_use_case.dart
@@ -12,7 +12,8 @@ class IsAuthorizedUseCase extends NoParamsUseCase<bool> {
 
   @override
   Future<Result<bool>> call() async {
-    final isAuthorized = await _persistence.accessToken != null;
+    final result = await _persistence.accessToken;
+    final isAuthorized = result != null && result.isNotEmpty;
 
     return Success(isAuthorized);
   }

--- a/test/usecase/is_authorized_use_case_test.dart
+++ b/test/usecase/is_authorized_use_case_test.dart
@@ -27,9 +27,20 @@ void main() {
     });
 
     test(
-        'When calling IsAuthorizedUseCase with result is false, it returns the result Success with false',
+        'When calling IsAuthorizedUseCase with result is null, it returns the result Success with false',
         () async {
       when(mockPersistence.accessToken).thenAnswer((_) async => null);
+
+      final result = await useCase.call();
+
+      expect(result, isA<Success>());
+      expect((result as Success).value, false);
+    });
+
+    test(
+        'When calling IsAuthorizedUseCase with result is empty, it returns the result Success with false',
+        () async {
+      when(mockPersistence.accessToken).thenAnswer((_) async => '');
 
       final result = await useCase.call();
 


### PR DESCRIPTION
 #54

## What happened 👀

To verify the proper functionality and behavior of the `SplashScreen` component.

## Insight 📝

- To ensure the `accessToken` is not empty we will handle it in `IsAuthorizedUseCase`, if empty -> return `false` 
- Create `splashScreenTest`.
- To simulate the value  of `accessToken` in storage, we can use `FlutterSecureStorage.setMockInitialValues` with the defined `key` and `value`:
  ```// Initializes the shared preferences with mock values for testing.
  @visibleForTesting
  static void setMockInitialValues(Map<String, String> values) {
    FlutterSecureStoragePlatform.instance =
        TestFlutterSecureStoragePlatform(values);
  }
  ```

## Proof Of Work 📹

https://github.com/Wadeewee/survey-flutter-ic-pooh/assets/28002315/418b8fa2-867e-4f5b-804d-25fe28934181

