### PR TITLE
[#13] [#14] [UI] [Integrate] As a user, I can see emoji rating answer

### DIFF
--- a/lib/ui/survey_question/answer/answer_dropdown.dart
+++ b/lib/ui/survey_question/answer/answer_dropdown.dart
@@ -1,16 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_picker/flutter_picker.dart';
+import 'package:survey_flutter_ic/extension/toast_extension.dart';
 import 'package:survey_flutter_ic/model/survey_answer_model.dart';
 import 'package:survey_flutter_ic/theme/dimens.dart';
 
 class AnswerDropdown extends StatelessWidget {
   final List<SurveyAnswerModel> answers;
-  final Function(SurveyAnswerModel) onSelect;
 
   const AnswerDropdown({
     super.key,
     required this.answers,
-    required this.onSelect,
   });
 
   @override
@@ -50,7 +49,8 @@ class AnswerDropdown extends StatelessWidget {
         itemExtent: dropdownItemHeight,
         hideHeader: true,
         onSelect: (picker, index, selected) {
-          onSelect.call(answers[selected.first]);
+          // TODO: Trigger VM on Integration of submit task
+          showToastMessage(answers[selected.first].text);
         },
       ).makePicker(),
     );

--- a/lib/ui/survey_question/answer/answer_emoji_rating.dart
+++ b/lib/ui/survey_question/answer/answer_emoji_rating.dart
@@ -5,12 +5,12 @@ import 'package:survey_flutter_ic/model/survey_answer_model.dart';
 import 'package:survey_flutter_ic/model/survey_question_model.dart';
 import 'package:survey_flutter_ic/theme/dimens.dart';
 
-const defaultSelectedEmojiIndex = 2;
-const maxAnswerChoices = 5;
-const List<String> faceModes = ['😡', '😕', '😐', '🙂', '😄'];
+const _defaultSelectedEmojiIndex = 2;
+const _maxAnswerChoices = 5;
+const List<String> _faceModes = ['😡', '😕', '😐', '🙂', '😄'];
 
 final selectedEmojiIndexProvider =
-    StateProvider.autoDispose<int>((_) => defaultSelectedEmojiIndex);
+    StateProvider.autoDispose<int>((_) => _defaultSelectedEmojiIndex);
 
 class AnswerEmojiRating extends ConsumerWidget {
   final DisplayType displayType;
@@ -29,7 +29,7 @@ class AnswerEmojiRating extends ConsumerWidget {
     return ListView.separated(
       shrinkWrap: true,
       scrollDirection: Axis.horizontal,
-      itemCount: maxAnswerChoices,
+      itemCount: _maxAnswerChoices,
       itemBuilder: (context, index) {
         return GestureDetector(
           onTap: () {
@@ -39,9 +39,9 @@ class AnswerEmojiRating extends ConsumerWidget {
           },
           child: Center(
             child: Text(
-              getEmoji(displayType, index),
+              _getEmoji(displayType, index),
               style: TextStyle(
-                color: getColor(displayType, index, selectedAnswerIndex),
+                color: _getColor(displayType, index, selectedAnswerIndex),
                 fontSize: fontSize34,
               ),
             ),
@@ -54,13 +54,13 @@ class AnswerEmojiRating extends ConsumerWidget {
     );
   }
 
-  String getEmoji(
+  String _getEmoji(
     DisplayType displayType,
     int index,
   ) {
     switch (displayType) {
       case DisplayType.smiley:
-        return faceModes[index];
+        return _faceModes[index];
       case DisplayType.star:
         return '⭐️';
       case DisplayType.heart:
@@ -70,7 +70,7 @@ class AnswerEmojiRating extends ConsumerWidget {
     }
   }
 
-  Color getColor(
+  Color _getColor(
     DisplayType displayType,
     int index,
     int selectedAnswerIndex,

--- a/lib/ui/survey_question/answer/answer_emoji_rating.dart
+++ b/lib/ui/survey_question/answer/answer_emoji_rating.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:survey_flutter_ic/extension/toast_extension.dart';
+import 'package:survey_flutter_ic/model/survey_answer_model.dart';
+import 'package:survey_flutter_ic/model/survey_question_model.dart';
+import 'package:survey_flutter_ic/theme/dimens.dart';
+
+const defaultSelectedEmojiIndex = 2;
+const maxAnswerChoices = 5;
+const List<String> faceModes = ['😡', '😕', '😐', '🙂', '😄'];
+
+final selectedEmojiIndexProvider =
+    StateProvider.autoDispose<int>((_) => defaultSelectedEmojiIndex);
+
+class AnswerEmojiRating extends ConsumerWidget {
+  final DisplayType displayType;
+  final List<SurveyAnswerModel> answers;
+
+  const AnswerEmojiRating({
+    super.key,
+    required this.displayType,
+    required this.answers,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final selectedAnswerIndex = ref.watch(selectedEmojiIndexProvider);
+
+    return ListView.separated(
+      shrinkWrap: true,
+      scrollDirection: Axis.horizontal,
+      itemCount: maxAnswerChoices,
+      itemBuilder: (context, index) {
+        return GestureDetector(
+          onTap: () {
+            ref.read(selectedEmojiIndexProvider.notifier).state = index;
+            // TODO: Trigger VM on Integration of submit task and reset index to default
+            showToastMessage(answers[index].text);
+          },
+          child: Center(
+            child: Text(
+              getEmoji(displayType, index),
+              style: TextStyle(
+                color: getColor(displayType, index, selectedAnswerIndex),
+                fontSize: fontSize34,
+              ),
+            ),
+          ),
+        );
+      },
+      separatorBuilder: (_, __) {
+        return const SizedBox(width: space20);
+      },
+    );
+  }
+
+  String getEmoji(
+    DisplayType displayType,
+    int index,
+  ) {
+    switch (displayType) {
+      case DisplayType.smiley:
+        return faceModes[index];
+      case DisplayType.star:
+        return '⭐️';
+      case DisplayType.heart:
+        return '❤️';
+      default:
+        return '👍🏻';
+    }
+  }
+
+  Color getColor(
+    DisplayType displayType,
+    int index,
+    int selectedAnswerIndex,
+  ) {
+    if (displayType == DisplayType.smiley) {
+      return index == selectedAnswerIndex
+          ? Colors.black
+          : Colors.black.withOpacity(0.5);
+    } else {
+      return index <= selectedAnswerIndex
+          ? Colors.black
+          : Colors.black.withOpacity(0.5);
+    }
+  }
+}

--- a/lib/ui/survey_question/survey_question_item.dart
+++ b/lib/ui/survey_question/survey_question_item.dart
@@ -20,8 +20,16 @@ class SurveyQuestionItem extends StatelessWidget {
   Widget _buildPageItem(SurveyQuestionModel surveyQuestion) {
     return Column(
       children: [
-        _buildQuestionLabel(surveyQuestion.text),
-        Expanded(child: _buildAnswerItem()),
+        if (surveyQuestion.answers.isNotEmpty)
+          _buildQuestionLabel(surveyQuestion.text)
+        else
+          Expanded(
+            child: SingleChildScrollView(
+              child: _buildQuestionLabel(surveyQuestion.text),
+            ),
+          ),
+        if (surveyQuestion.answers.isNotEmpty)
+          Expanded(child: _buildAnswerItem())
       ],
     );
   }

--- a/lib/ui/survey_question/survey_question_item.dart
+++ b/lib/ui/survey_question/survey_question_item.dart
@@ -1,17 +1,15 @@
 import 'package:flutter/material.dart';
-import 'package:survey_flutter_ic/model/survey_answer_model.dart';
 import 'package:survey_flutter_ic/model/survey_question_model.dart';
 import 'package:survey_flutter_ic/theme/dimens.dart';
 import 'package:survey_flutter_ic/ui/survey_question/answer/answer_dropdown.dart';
+import 'package:survey_flutter_ic/ui/survey_question/answer/answer_emoji_rating.dart';
 
 class SurveyQuestionItem extends StatelessWidget {
   final SurveyQuestionModel surveyQuestion;
-  final Function(SurveyAnswerModel) onDropdownSelect;
 
   const SurveyQuestionItem({
     super.key,
     required this.surveyQuestion,
-    required this.onDropdownSelect,
   });
 
   @override
@@ -23,13 +21,7 @@ class SurveyQuestionItem extends StatelessWidget {
     return Column(
       children: [
         _buildQuestionLabel(surveyQuestion.text),
-        Expanded(
-          // TODO: Handle widget to match with display type
-          child: AnswerDropdown(
-            answers: surveyQuestion.answers,
-            onSelect: (result) => onDropdownSelect.call(result),
-          ),
-        ),
+        Expanded(child: _buildAnswerItem()),
       ],
     );
   }
@@ -43,5 +35,23 @@ class SurveyQuestionItem extends StatelessWidget {
         fontWeight: FontWeight.w800,
       ),
     );
+  }
+
+  Widget _buildAnswerItem() {
+    switch (surveyQuestion.displayType) {
+      case DisplayType.dropdown:
+        return AnswerDropdown(
+          answers: surveyQuestion.answers,
+        );
+      case DisplayType.smiley:
+      case DisplayType.star:
+      case DisplayType.heart:
+        return AnswerEmojiRating(
+          displayType: surveyQuestion.displayType,
+          answers: surveyQuestion.answers,
+        );
+      default:
+        return const SizedBox.shrink();
+    }
   }
 }

--- a/lib/ui/survey_question/survey_questions_screen.dart
+++ b/lib/ui/survey_question/survey_questions_screen.dart
@@ -160,9 +160,6 @@ class _SurveyQuestionsState extends ConsumerState<SurveyQuestionsScreen> {
       itemCount: surveyQuestions.length,
       itemBuilder: (_, index) => SurveyQuestionItem(
         surveyQuestion: surveyQuestions[currentIndex],
-        onDropdownSelect: (result) {
-          // TODO: Trigger VM on Integration task
-        },
       ),
     );
   }


### PR DESCRIPTION
#13
#14

## What happened 👀

- For Emoji Rating questions,
    - Display emojis as the options
        - By default, use 👍🏻 emoji.
        - Please note that it could be other emojis as well depending on the question type.
    - Select any option should highlight every other emoji on its left
        - For instance, if a user selects the third emoji, the first, second, and third emoji should be highlighted.
    - Reduce the opacity of the non-selected range emojis

- For Smiley Rating questions,
    - Display 5 Smiley emojis as the options - 😡 😕 😐 🙂 😄
    - Select any option should highlight ONLY the selected one
        - For instance, if a user selects the third smiley, only third smiley 
should be highlighted.
    - Reduce the opacity of the non-selected emojis

## Insight 📝

- Add the `_buildAnswerItem()` widget to handle the display type view of the answer.
- Create `AnswerEmojiRating` to display the answer  type of `smiley, heart, and star.`

## Proof Of Work 📹

https://github.com/Wadeewee/survey-flutter-ic-pooh/assets/28002315/96050634-fe6f-4534-8c82-6030c1e2163d

https://github.com/Wadeewee/survey-flutter-ic-pooh/assets/28002315/dd296f14-12cf-400c-9da1-5b5b59498a40

