### PR TITLE
[#17] [UI] As a user, I can see text area answer

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -5,6 +5,8 @@
 
   "survey_detail_start_survey_button": "Start survey",
 
+  "survey_question_textarea_hint": "Your thoughts",
+
   "sign_in_email_label": "Email",
   "sign_in_button": "Log in",
   "sign_in_password_label": "Password"

--- a/lib/ui/survey_question/answer/answer_dropdown.dart
+++ b/lib/ui/survey_question/answer/answer_dropdown.dart
@@ -14,8 +14,7 @@ class AnswerDropdown extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Align(
-      alignment: Alignment.center,
+    return Center(
       child: Picker(
         adapter: PickerDataAdapter<String>(
           pickerData: answers.map((answer) => answer.text).toList(),

--- a/lib/ui/survey_question/answer/answer_textarea.dart
+++ b/lib/ui/survey_question/answer/answer_textarea.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:survey_flutter_ic/extension/context_extension.dart';
+import 'package:survey_flutter_ic/extension/toast_extension.dart';
+import 'package:survey_flutter_ic/model/survey_answer_model.dart';
+import 'package:survey_flutter_ic/theme/dimens.dart';
+
+class AnswerTextArea extends StatelessWidget {
+  final List<SurveyAnswerModel> answers;
+
+  const AnswerTextArea({
+    super.key,
+    required this.answers,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: TextField(
+        style: const TextStyle(
+          color: Colors.white,
+          fontSize: fontSize17,
+          fontWeight: FontWeight.w400,
+        ),
+        decoration: InputDecoration(
+          filled: true,
+          fillColor: Colors.white.withOpacity(0.2),
+          border: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(borderRadius10),
+            borderSide: BorderSide.none,
+          ),
+          hintText: context.localization.survey_question_textarea_hint,
+          hintStyle: TextStyle(
+            color: Colors.white.withOpacity(0.3),
+            fontSize: fontSize17,
+          ),
+        ),
+        cursorColor: Colors.white,
+        textInputAction: TextInputAction.done,
+        maxLines: 10,
+        onChanged: (input) => {
+          // TODO: Trigger VM on Integration of submit task
+        },
+        onSubmitted: (input) => {
+          // TODO: Trigger VM on Integration of submit task
+          showToastMessage(input)
+        },
+      ),
+    );
+  }
+}

--- a/lib/ui/survey_question/survey_question_item.dart
+++ b/lib/ui/survey_question/survey_question_item.dart
@@ -3,6 +3,7 @@ import 'package:survey_flutter_ic/model/survey_question_model.dart';
 import 'package:survey_flutter_ic/theme/dimens.dart';
 import 'package:survey_flutter_ic/ui/survey_question/answer/answer_dropdown.dart';
 import 'package:survey_flutter_ic/ui/survey_question/answer/answer_emoji_rating.dart';
+import 'package:survey_flutter_ic/ui/survey_question/answer/answer_textarea.dart';
 
 class SurveyQuestionItem extends StatelessWidget {
   final SurveyQuestionModel surveyQuestion;
@@ -41,6 +42,10 @@ class SurveyQuestionItem extends StatelessWidget {
     switch (surveyQuestion.displayType) {
       case DisplayType.dropdown:
         return AnswerDropdown(
+          answers: surveyQuestion.answers,
+        );
+      case DisplayType.textarea:
+        return AnswerTextArea(
           answers: surveyQuestion.answers,
         );
       case DisplayType.smiley:


### PR DESCRIPTION
#17

## What happened 👀

For text-area questions,
- Display a textbox that supports multi-line text input
    - Display a placeholder inside the textbox
    - The textbox is scrollable when the number of lines goes beyond its viewport (i.e., when the text input no longer fits within the textbox)
- Display the keyboard when a textbox is selected
    - Tap anywhere outside of textbox to release the keyboard
    - The keyboard must not cover what the user is typing

## Insight 📝

- Create `AnswerTextArea` to display the answer type of ` textarea`.

## Proof Of Work 📹

https://github.com/Wadeewee/survey-flutter-ic-pooh/assets/28002315/6c377891-4fca-4142-a58f-e40b05aeccbc

