### PR TITLE
[#18] [#19] [UI] [Integrate] As a user, I can see form answers

### DIFF
--- a/lib/ui/survey_question/answer/answer_emoji_rating.dart
+++ b/lib/ui/survey_question/answer/answer_emoji_rating.dart
@@ -30,7 +30,7 @@ class AnswerEmojiRating extends ConsumerWidget {
       shrinkWrap: true,
       scrollDirection: Axis.horizontal,
       itemCount: _maxAnswerChoices,
-      itemBuilder: (context, index) {
+      itemBuilder: (_, index) {
         return GestureDetector(
           onTap: () {
             ref.read(selectedEmojiIndexProvider.notifier).state = index;

--- a/lib/ui/survey_question/answer/answer_form.dart
+++ b/lib/ui/survey_question/answer/answer_form.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:survey_flutter_ic/extension/toast_extension.dart';
+import 'package:survey_flutter_ic/model/survey_answer_model.dart';
+import 'package:survey_flutter_ic/theme/dimens.dart';
+
+class AnswerForm extends StatelessWidget {
+  final List<SurveyAnswerModel> answers;
+
+  const AnswerForm({
+    super.key,
+    required this.answers,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: ListView.separated(
+        shrinkWrap: true,
+        itemCount: answers.length,
+        itemBuilder: (_, index) {
+          return _buildTextFieldItem(index);
+        },
+        separatorBuilder: (_, __) {
+          return const SizedBox(height: space16);
+        },
+      ),
+    );
+  }
+
+  Widget _buildTextFieldItem(int index) {
+    return TextField(
+      style: const TextStyle(
+        color: Colors.white,
+        fontSize: fontSize17,
+        fontWeight: FontWeight.w400,
+      ),
+      decoration: InputDecoration(
+        filled: true,
+        fillColor: Colors.white.withOpacity(0.2),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(borderRadius10),
+          borderSide: BorderSide.none,
+        ),
+        hintText: answers[index].text,
+        hintStyle: TextStyle(
+          color: Colors.white.withOpacity(0.3),
+          fontSize: fontSize17,
+        ),
+      ),
+      cursorColor: Colors.white,
+      keyboardType: _getTextInputType(index),
+      textInputAction: index == (answers.length - 1)
+          ? TextInputAction.done
+          : TextInputAction.next,
+      onChanged: (input) => {
+        // TODO: Trigger VM on Integration of submit task
+      },
+      onSubmitted: (input) => {
+        // TODO: Trigger VM on Integration of submit task
+        showToastMessage(input)
+      },
+    );
+  }
+
+  TextInputType _getTextInputType(int index) {
+    final text = answers[index].text.toLowerCase();
+
+    if (text.contains('mobile') || text.contains('phone')) {
+      return TextInputType.phone;
+    } else if (text.contains('email')) {
+      return TextInputType.emailAddress;
+    } else if (text.contains('room')) {
+      return TextInputType.number;
+    } else {
+      return TextInputType.text;
+    }
+  }
+}

--- a/lib/ui/survey_question/answer/answer_form.dart
+++ b/lib/ui/survey_question/answer/answer_form.dart
@@ -52,12 +52,12 @@ class AnswerForm extends StatelessWidget {
       textInputAction: index == (answers.length - 1)
           ? TextInputAction.done
           : TextInputAction.next,
-      onChanged: (input) => {
+      onChanged: (input) {
         // TODO: Trigger VM on Integration of submit task
       },
-      onSubmitted: (input) => {
+      onSubmitted: (input) {
         // TODO: Trigger VM on Integration of submit task
-        showToastMessage(input)
+        showToastMessage(input);
       },
     );
   }

--- a/lib/ui/survey_question/survey_question_item.dart
+++ b/lib/ui/survey_question/survey_question_item.dart
@@ -3,6 +3,7 @@ import 'package:survey_flutter_ic/model/survey_question_model.dart';
 import 'package:survey_flutter_ic/theme/dimens.dart';
 import 'package:survey_flutter_ic/ui/survey_question/answer/answer_dropdown.dart';
 import 'package:survey_flutter_ic/ui/survey_question/answer/answer_emoji_rating.dart';
+import 'package:survey_flutter_ic/ui/survey_question/answer/answer_form.dart';
 import 'package:survey_flutter_ic/ui/survey_question/answer/answer_textarea.dart';
 
 class SurveyQuestionItem extends StatelessWidget {
@@ -54,6 +55,10 @@ class SurveyQuestionItem extends StatelessWidget {
         );
       case DisplayType.textarea:
         return AnswerTextArea(
+          answers: surveyQuestion.answers,
+        );
+      case DisplayType.textfield:
+        return AnswerForm(
           answers: surveyQuestion.answers,
         );
       case DisplayType.smiley:

--- a/lib/ui/survey_question/survey_questions_screen.dart
+++ b/lib/ui/survey_question/survey_questions_screen.dart
@@ -72,6 +72,7 @@ class _SurveyQuestionsState extends ConsumerState<SurveyQuestionsScreen> {
         children: [
           _buildCoverImageUrl(
             surveyQuestions[currentIndex].largeCoverImageUrl,
+            surveyQuestions[currentIndex].coverImageOpacity,
           ),
           SafeArea(
             child: Padding(
@@ -114,18 +115,25 @@ class _SurveyQuestionsState extends ConsumerState<SurveyQuestionsScreen> {
     );
   }
 
-  Widget _buildCoverImageUrl(String largeCoverImageUrl) {
+  Widget _buildCoverImageUrl(
+    String largeCoverImageUrl,
+    double coverImageOpacity,
+  ) {
     return Container(
       width: double.infinity,
       height: double.infinity,
       decoration: BoxDecoration(
         image: DecorationImage(
           image: Image.network(largeCoverImageUrl).image,
+          colorFilter: ColorFilter.mode(
+            Colors.black.withOpacity(coverImageOpacity),
+            BlendMode.darken,
+          ),
           fit: BoxFit.cover,
         ),
       ),
       child: BackdropFilter(
-        filter: ImageFilter.blur(sigmaX: 10.0, sigmaY: 10.0),
+        filter: ImageFilter.blur(sigmaX: 5.0, sigmaY: 5.0),
         child: const SizedBox(),
       ),
     );


### PR DESCRIPTION
#18
#19

## What happened 👀

For textfield questions,
- Display an inline textfield
    - Display a placeholder in the textfield
    - When a textfield is not empty, increase the opacity
- Display the keyboard when a textfield is selected
    - Tap anywhere outside of the textfield to release the keyboard
    - The keyboard must not cover the selected textfield

## Insight 📝

- Create `AnswerForm` to display the answer type of `textfield`.
- We need to add a `ColorFilter` with `coverImageOpacity` from the `API` to the BoxDecoration of the container and set `BlendMode.darken` to make the `TextField` more visible when the background is too light.

## Proof Of Work 📹

https://github.com/Wadeewee/survey-flutter-ic-pooh/assets/28002315/b1f90fe8-2a5c-49b1-93fa-efb63b243884


https://github.com/Wadeewee/survey-flutter-ic-pooh/assets/28002315/dd0a5cdf-5ab6-4cf3-84e6-055cf942fdd8


