### PR TITLE
[#15][#16] [UI] [Integrate] As a user, I can see nps answer

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -3,11 +3,14 @@
 
   "home_today": "Today",
 
-  "survey_detail_start_survey_button": "Start survey",
-
-  "survey_question_textarea_hint": "Your thoughts",
-
   "sign_in_email_label": "Email",
   "sign_in_button": "Log in",
-  "sign_in_password_label": "Password"
+  "sign_in_password_label": "Password",
+
+  "survey_detail_start_survey_button": "Start survey",
+
+  "survey_question_nps_lowest_description": "Not at all Likely",
+  "survey_question_nps_highest_description": "Extremely Likely",
+
+  "survey_question_textarea_hint": "Your thoughts"
 }

--- a/lib/theme/dimens.dart
+++ b/lib/theme/dimens.dart
@@ -22,3 +22,5 @@ const double pagerIndicatorSize = 8.0;
 
 const double dropdownItemHeight = 56.0;
 const double dropdownItemDividerHeight = 0.5;
+
+const double npsAnswerHeight = 60.0;

--- a/lib/ui/survey_question/answer/answer_nps.dart
+++ b/lib/ui/survey_question/answer/answer_nps.dart
@@ -1,0 +1,130 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:survey_flutter_ic/extension/context_extension.dart';
+import 'package:survey_flutter_ic/extension/toast_extension.dart';
+import 'package:survey_flutter_ic/model/survey_answer_model.dart';
+import 'package:survey_flutter_ic/theme/dimens.dart';
+
+const _defaultSelectedNpsIndex = -1;
+const _maxAnswerChoices = 10;
+const _lowestThreshold = 3;
+const _highestThreshold = 8;
+
+final selectedNpsIndexProvider =
+    StateProvider.autoDispose<int>((_) => _defaultSelectedNpsIndex);
+
+class AnswerNps extends ConsumerWidget {
+  final List<SurveyAnswerModel> answers;
+
+  const AnswerNps({
+    super.key,
+    required this.answers,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final selectedAnswerIndex = ref.watch(selectedNpsIndexProvider);
+
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Container(
+          height: npsAnswerHeight,
+          decoration: BoxDecoration(
+            border: Border.all(
+              color: Colors.white,
+              width: 1,
+            ),
+            borderRadius: BorderRadius.circular(space10),
+          ),
+          child: Row(
+            children: List.generate(
+              _maxAnswerChoices,
+              (index) {
+                return Expanded(
+                  child: GestureDetector(
+                    onTap: () {
+                      ref.read(selectedNpsIndexProvider.notifier).state = index;
+                      // TODO: Trigger VM on Integration of submit task
+                      showToastMessage((index + 1).toString());
+                    },
+                    child: _buildItem(index, selectedAnswerIndex),
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+        const SizedBox(height: space16),
+        _buildDescription(
+          selectedAnswerIndex + 1,
+          context.localization.survey_question_nps_lowest_description,
+          context.localization.survey_question_nps_highest_description,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildItem(
+    int index,
+    int selectedAnswerIndex,
+  ) {
+    return Container(
+      decoration: BoxDecoration(
+        border: Border(
+          right: BorderSide(
+            color: (index == _maxAnswerChoices - 1)
+                ? Colors.transparent
+                : Colors.white,
+          ),
+        ),
+      ),
+      child: Center(
+        child: Text(
+          (index + 1).toString(),
+          style: TextStyle(
+            color: index <= selectedAnswerIndex
+                ? Colors.white
+                : Colors.white.withOpacity(0.5),
+            fontSize: fontSize17,
+            fontWeight: index <= selectedAnswerIndex
+                ? FontWeight.w800
+                : FontWeight.w400,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDescription(
+    int index,
+    String lowestDescriptionThreshold,
+    String highestDescriptionThreshold,
+  ) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(
+          lowestDescriptionThreshold,
+          style: TextStyle(
+            fontSize: fontSize17,
+            color: index <= _lowestThreshold
+                ? Colors.white
+                : Colors.white.withOpacity(0.5),
+            fontWeight: FontWeight.w800,
+          ),
+        ),
+        Text(
+          highestDescriptionThreshold,
+          style: TextStyle(
+            fontSize: fontSize17,
+            color: index >= _highestThreshold
+                ? Colors.white
+                : Colors.white.withOpacity(0.5),
+            fontWeight: FontWeight.w800,
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/ui/survey_question/survey_question_item.dart
+++ b/lib/ui/survey_question/survey_question_item.dart
@@ -4,6 +4,7 @@ import 'package:survey_flutter_ic/theme/dimens.dart';
 import 'package:survey_flutter_ic/ui/survey_question/answer/answer_dropdown.dart';
 import 'package:survey_flutter_ic/ui/survey_question/answer/answer_emoji_rating.dart';
 import 'package:survey_flutter_ic/ui/survey_question/answer/answer_form.dart';
+import 'package:survey_flutter_ic/ui/survey_question/answer/answer_nps.dart';
 import 'package:survey_flutter_ic/ui/survey_question/answer/answer_textarea.dart';
 
 class SurveyQuestionItem extends StatelessWidget {
@@ -59,6 +60,10 @@ class SurveyQuestionItem extends StatelessWidget {
         );
       case DisplayType.textfield:
         return AnswerForm(
+          answers: surveyQuestion.answers,
+        );
+      case DisplayType.nps:
+        return AnswerNps(
           answers: surveyQuestion.answers,
         );
       case DisplayType.smiley:


### PR DESCRIPTION
#15
#16

## What happened 👀

For NPS questions,
- Display the answers on a scale
- Select any option should highlight every other number on its left
    - For instance, if a user selects 5, 1-5 should be highlighted.
- Unhighlighted options must be grayed out and unbolded.
- Show the Not at all Likely label on the leftest of the scale
- Show the Extremely Likely label on the rightest of the scale

When a Question model has display_type as nps,
- Display an NPS scale in the Answer section
- The number of options (the scale range) must match the number of the answers.
- By default, none are initially selected.

## Insight 📝

- Create `AnswerNps` to display the answer type of `nps`.

## Proof Of Work 📹

https://github.com/Wadeewee/survey-flutter-ic-pooh/assets/28002315/7fb69204-236d-4994-9d40-a2a266a3f820


