### PR TITLE
[#23] [Backend] As a user, I can submit my survey response

### DIFF
--- a/lib/api/repository/survey_repository.dart
+++ b/lib/api/repository/survey_repository.dart
@@ -1,9 +1,11 @@
 import 'package:injectable/injectable.dart';
 import 'package:survey_flutter_ic/api/exception/network_exceptions.dart';
+import 'package:survey_flutter_ic/api/request/submit_survey_question_request.dart';
 import 'package:survey_flutter_ic/api/request/submit_survey_request.dart';
 import 'package:survey_flutter_ic/api/service/survey_service.dart';
 import 'package:survey_flutter_ic/database/dto/survey_dto.dart';
 import 'package:survey_flutter_ic/database/persistence/survey_persistence.dart';
+import 'package:survey_flutter_ic/model/submit_survey_question_model.dart';
 import 'package:survey_flutter_ic/model/survey_detail_model.dart';
 import 'package:survey_flutter_ic/model/survey_model.dart';
 
@@ -21,7 +23,10 @@ abstract class SurveyRepository {
 
   Future<void> saveSurveys(List<SurveyModel> surveys);
 
-  Future<void> submitSurvey({required SubmitSurveyRequest submitSurveyRequest});
+  Future<void> submitSurvey({
+    required String surveyId,
+    required List<SubmitSurveyQuestionModel> questions,
+  });
 }
 
 @LazySingleton(as: SurveyRepository)
@@ -85,10 +90,16 @@ class SurveyRepositoryImpl extends SurveyRepository {
 
   @override
   Future<void> submitSurvey({
-    required SubmitSurveyRequest submitSurveyRequest,
+    required String surveyId,
+    required List<SubmitSurveyQuestionModel> questions,
   }) async {
     try {
-      return await _surveyService.submitSurvey(submitSurveyRequest);
+      return await _surveyService.submitSurvey(SubmitSurveyRequest(
+        surveyId: surveyId,
+        questions: questions
+            .map((model) => SubmitSurveyQuestionRequest.fromModel(model))
+            .toList(),
+      ));
     } catch (exception) {
       throw NetworkExceptions.fromDioException(exception);
     }

--- a/lib/api/repository/survey_repository.dart
+++ b/lib/api/repository/survey_repository.dart
@@ -1,5 +1,6 @@
 import 'package:injectable/injectable.dart';
 import 'package:survey_flutter_ic/api/exception/network_exceptions.dart';
+import 'package:survey_flutter_ic/api/request/submit_survey_request.dart';
 import 'package:survey_flutter_ic/api/service/survey_service.dart';
 import 'package:survey_flutter_ic/database/dto/survey_dto.dart';
 import 'package:survey_flutter_ic/database/persistence/survey_persistence.dart';
@@ -19,6 +20,8 @@ abstract class SurveyRepository {
   Future<List<SurveyModel>> getCachedSurveys();
 
   Future<void> saveSurveys(List<SurveyModel> surveys);
+
+  Future<void> submitSurvey({required SubmitSurveyRequest submitSurveyRequest});
 }
 
 @LazySingleton(as: SurveyRepository)
@@ -78,5 +81,16 @@ class SurveyRepositoryImpl extends SurveyRepository {
 
   Future<void> clearCachedSurveys() async {
     _surveyPersistence.clear();
+  }
+
+  @override
+  Future<void> submitSurvey({
+    required SubmitSurveyRequest submitSurveyRequest,
+  }) async {
+    try {
+      return await _surveyService.submitSurvey(submitSurveyRequest);
+    } catch (exception) {
+      throw NetworkExceptions.fromDioException(exception);
+    }
   }
 }

--- a/lib/api/request/submit_survey_answer_request.dart
+++ b/lib/api/request/submit_survey_answer_request.dart
@@ -1,0 +1,27 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:survey_flutter_ic/model/submit_survey_answer_model.dart';
+
+part 'submit_survey_answer_request.g.dart';
+
+@JsonSerializable()
+class SubmitSurveyAnswerRequest {
+  final String id;
+  final String answer;
+
+  SubmitSurveyAnswerRequest({
+    required this.id,
+    required this.answer,
+  });
+
+  factory SubmitSurveyAnswerRequest.fromJson(Map<String, dynamic> json) =>
+      _$SubmitSurveyAnswerRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SubmitSurveyAnswerRequestToJson(this);
+
+  factory SubmitSurveyAnswerRequest.fromModel(SubmitSurveyAnswerModel model) {
+    return SubmitSurveyAnswerRequest(
+      id: model.id,
+      answer: model.answer,
+    );
+  }
+}

--- a/lib/api/request/submit_survey_question_request.dart
+++ b/lib/api/request/submit_survey_question_request.dart
@@ -1,0 +1,32 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:survey_flutter_ic/api/request/submit_survey_answer_request.dart';
+import 'package:survey_flutter_ic/model/submit_survey_question_model.dart';
+
+part 'submit_survey_question_request.g.dart';
+
+@JsonSerializable()
+class SubmitSurveyQuestionRequest {
+  final String id;
+  final List<SubmitSurveyAnswerRequest> answers;
+
+  SubmitSurveyQuestionRequest({
+    required this.id,
+    required this.answers,
+  });
+
+  factory SubmitSurveyQuestionRequest.fromJson(Map<String, dynamic> json) =>
+      _$SubmitSurveyQuestionRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SubmitSurveyQuestionRequestToJson(this);
+
+  factory SubmitSurveyQuestionRequest.fromModel(
+    SubmitSurveyQuestionModel model,
+  ) {
+    return SubmitSurveyQuestionRequest(
+      id: model.id,
+      answers: model.answers
+          .map((answer) => SubmitSurveyAnswerRequest.fromModel(answer))
+          .toList(),
+    );
+  }
+}

--- a/lib/api/request/submit_survey_request.dart
+++ b/lib/api/request/submit_survey_request.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:survey_flutter_ic/api/request/submit_survey_question_request.dart';
+
+part 'submit_survey_request.g.dart';
+
+@JsonSerializable()
+class SubmitSurveyRequest {
+  final String surveyId;
+  final List<SubmitSurveyQuestionRequest> questions;
+
+  SubmitSurveyRequest({
+    required this.surveyId,
+    required this.questions,
+  });
+
+  factory SubmitSurveyRequest.fromJson(Map<String, dynamic> json) =>
+      _$SubmitSurveyRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SubmitSurveyRequestToJson(this);
+}

--- a/lib/api/service/survey_service.dart
+++ b/lib/api/service/survey_service.dart
@@ -1,5 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:retrofit/http.dart';
+import 'package:survey_flutter_ic/api/request/submit_survey_request.dart';
 import 'package:survey_flutter_ic/api/response/survey_detail_response.dart';
 import 'package:survey_flutter_ic/api/response/surveys_response.dart';
 
@@ -13,6 +14,10 @@ abstract class SurveyService {
 
   Future<SurveyDetailResponse> getSurveyDetail(
     @Path('id') String id,
+  );
+
+  Future<void> submitSurvey(
+    @Body() SubmitSurveyRequest body,
   );
 }
 
@@ -31,5 +36,11 @@ abstract class SurveyServiceImpl extends SurveyService {
   @GET('/api/v1/surveys/{id}')
   Future<SurveyDetailResponse> getSurveyDetail(
     @Path('id') String id,
+  );
+
+  @override
+  @POST('/api/v1/responses')
+  Future<void> submitSurvey(
+    @Body() SubmitSurveyRequest body,
   );
 }

--- a/lib/model/submit_survey_answer_model.dart
+++ b/lib/model/submit_survey_answer_model.dart
@@ -1,0 +1,14 @@
+import 'package:equatable/equatable.dart';
+
+class SubmitSurveyAnswerModel extends Equatable {
+  final String id;
+  final String answer;
+
+  const SubmitSurveyAnswerModel({
+    required this.id,
+    required this.answer,
+  });
+
+  @override
+  List<Object> get props => [id, answer];
+}

--- a/lib/model/submit_survey_question_model.dart
+++ b/lib/model/submit_survey_question_model.dart
@@ -1,0 +1,15 @@
+import 'package:equatable/equatable.dart';
+import 'package:survey_flutter_ic/model/submit_survey_answer_model.dart';
+
+class SubmitSurveyQuestionModel extends Equatable {
+  final String id;
+  final List<SubmitSurveyAnswerModel> answers;
+
+  const SubmitSurveyQuestionModel({
+    required this.id,
+    required this.answers,
+  });
+
+  @override
+  List<Object> get props => [id, answers];
+}

--- a/lib/usecase/submit_survey_use_case.dart
+++ b/lib/usecase/submit_survey_use_case.dart
@@ -1,0 +1,22 @@
+import 'package:injectable/injectable.dart';
+import 'package:survey_flutter_ic/api/exception/network_exceptions.dart';
+import 'package:survey_flutter_ic/api/repository/survey_repository.dart';
+import 'package:survey_flutter_ic/api/request/submit_survey_request.dart';
+import 'package:survey_flutter_ic/usecase/base/base_use_case.dart';
+
+@Injectable()
+class SubmitSurveyUseCase extends UseCase<void, SubmitSurveyRequest> {
+  final SurveyRepository _repository;
+
+  const SubmitSurveyUseCase(this._repository);
+
+  @override
+  Future<Result<void>> call(SubmitSurveyRequest params) {
+    return _repository
+        .submitSurvey(submitSurveyRequest: params)
+        // ignore: unnecessary_cast
+        .then((value) => Success(value) as Result<void>)
+        .onError<NetworkExceptions>(
+            (exception, stackTrace) => Failed(UseCaseException(exception)));
+  }
+}

--- a/lib/usecase/submit_survey_use_case.dart
+++ b/lib/usecase/submit_survey_use_case.dart
@@ -1,19 +1,32 @@
 import 'package:injectable/injectable.dart';
 import 'package:survey_flutter_ic/api/exception/network_exceptions.dart';
 import 'package:survey_flutter_ic/api/repository/survey_repository.dart';
-import 'package:survey_flutter_ic/api/request/submit_survey_request.dart';
+import 'package:survey_flutter_ic/model/submit_survey_question_model.dart';
 import 'package:survey_flutter_ic/usecase/base/base_use_case.dart';
 
+class SubmitSurveyUseCaseInput {
+  final String surveyId;
+  final List<SubmitSurveyQuestionModel> questions;
+
+  SubmitSurveyUseCaseInput({
+    required this.surveyId,
+    required this.questions,
+  });
+}
+
 @Injectable()
-class SubmitSurveyUseCase extends UseCase<void, SubmitSurveyRequest> {
+class SubmitSurveyUseCase extends UseCase<void, SubmitSurveyUseCaseInput> {
   final SurveyRepository _repository;
 
   const SubmitSurveyUseCase(this._repository);
 
   @override
-  Future<Result<void>> call(SubmitSurveyRequest params) {
+  Future<Result<void>> call(SubmitSurveyUseCaseInput params) {
     return _repository
-        .submitSurvey(submitSurveyRequest: params)
+        .submitSurvey(
+          surveyId: params.surveyId,
+          questions: params.questions,
+        )
         // ignore: unnecessary_cast
         .then((value) => Success(value) as Result<void>)
         .onError<NetworkExceptions>(

--- a/test/api/repository/survey_repository_test.dart
+++ b/test/api/repository/survey_repository_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_config/flutter_config.dart';
 import 'package:survey_flutter_ic/api/exception/network_exceptions.dart';
 import 'package:survey_flutter_ic/api/repository/survey_repository.dart';
+import 'package:survey_flutter_ic/api/request/submit_survey_request.dart';
 import 'package:survey_flutter_ic/api/response/survey_detail_response.dart';
 import 'package:survey_flutter_ic/api/response/surveys_response.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -36,6 +37,11 @@ void main() {
     ];
 
     final surveys = surveysDto.map((e) => SurveyModel.fromDto(e)).toList();
+
+    final submitSurveyRequest = SubmitSurveyRequest(
+      surveyId: 'survey_id',
+      questions: [],
+    );
 
     setUp(() {
       mockSurveyService = MockSurveyService();
@@ -134,6 +140,27 @@ void main() {
         mockSurveyPersistence.clear(),
         mockSurveyPersistence.add(surveysDto),
       ]);
+    });
+
+    test('When calling SubmitSurvey successfully, it returns empty result',
+        () async {
+      when(mockSurveyService.submitSurvey(any)).thenAnswer((_) async => []);
+
+      final result = await repository.submitSurvey(
+        submitSurveyRequest: submitSurveyRequest,
+      );
+
+      expect(() async => result, isA<void>());
+    });
+
+    test('When calling SubmitSurvey failed, it returns NetworkExceptions error',
+        () async {
+      when(mockSurveyService.submitSurvey(any)).thenThrow(MockDioError());
+
+      result() =>
+          repository.submitSurvey(submitSurveyRequest: submitSurveyRequest);
+
+      expect(result, throwsA(isA<NetworkExceptions>()));
     });
   });
 }

--- a/test/api/repository/survey_repository_test.dart
+++ b/test/api/repository/survey_repository_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_config/flutter_config.dart';
 import 'package:survey_flutter_ic/api/exception/network_exceptions.dart';
 import 'package:survey_flutter_ic/api/repository/survey_repository.dart';
-import 'package:survey_flutter_ic/api/request/submit_survey_request.dart';
 import 'package:survey_flutter_ic/api/response/survey_detail_response.dart';
 import 'package:survey_flutter_ic/api/response/surveys_response.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -37,11 +36,6 @@ void main() {
     ];
 
     final surveys = surveysDto.map((e) => SurveyModel.fromDto(e)).toList();
-
-    final submitSurveyRequest = SubmitSurveyRequest(
-      surveyId: 'survey_id',
-      questions: [],
-    );
 
     setUp(() {
       mockSurveyService = MockSurveyService();
@@ -147,7 +141,8 @@ void main() {
       when(mockSurveyService.submitSurvey(any)).thenAnswer((_) async => []);
 
       final result = await repository.submitSurvey(
-        submitSurveyRequest: submitSurveyRequest,
+        surveyId: 'surveyId',
+        questions: [],
       );
 
       expect(() async => result, isA<void>());
@@ -157,8 +152,10 @@ void main() {
         () async {
       when(mockSurveyService.submitSurvey(any)).thenThrow(MockDioError());
 
-      result() =>
-          repository.submitSurvey(submitSurveyRequest: submitSurveyRequest);
+      result() => repository.submitSurvey(
+            surveyId: 'surveyId',
+            questions: [],
+          );
 
       expect(result, throwsA(isA<NetworkExceptions>()));
     });

--- a/test/mocks/generate_mocks.dart
+++ b/test/mocks/generate_mocks.dart
@@ -15,6 +15,7 @@ import 'package:survey_flutter_ic/usecase/get_profile_use_case.dart';
 import 'package:survey_flutter_ic/usecase/get_survey_detail_use_case.dart';
 import 'package:survey_flutter_ic/usecase/is_authorized_use_case.dart';
 import 'package:survey_flutter_ic/usecase/sign_in_use_case.dart';
+import 'package:survey_flutter_ic/usecase/submit_survey_use_case.dart';
 
 @GenerateMocks([
   AuthService,
@@ -33,6 +34,7 @@ import 'package:survey_flutter_ic/usecase/sign_in_use_case.dart';
   Box,
   IsAuthorizedUseCase,
   GetSurveyDetailUseCase,
+  SubmitSurveyUseCase,
 ])
 main() {
   // empty class to generate mock repository classes

--- a/test/usecase/submit_survey_use_case_test.dart
+++ b/test/usecase/submit_survey_use_case_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:survey_flutter_ic/api/exception/network_exceptions.dart';
-import 'package:survey_flutter_ic/api/request/submit_survey_request.dart';
 import 'package:survey_flutter_ic/usecase/base/base_use_case.dart';
 import 'package:survey_flutter_ic/usecase/submit_survey_use_case.dart';
 
@@ -17,7 +16,7 @@ void main() {
       useCase = SubmitSurveyUseCase(mockRepository);
     });
 
-    final submitSurveyRequest = SubmitSurveyRequest(
+    final input = SubmitSurveyUseCaseInput(
       surveyId: 'survey_id',
       questions: [],
     );
@@ -26,10 +25,13 @@ void main() {
         'When calling SubmitSurvey successfully, it returns the result Success',
         () async {
       when(
-        mockRepository.submitSurvey(submitSurveyRequest: submitSurveyRequest),
+        mockRepository.submitSurvey(
+          surveyId: input.surveyId,
+          questions: input.questions,
+        ),
       ).thenAnswer((_) async => (null));
 
-      final result = await useCase.call(submitSurveyRequest);
+      final result = await useCase.call(input);
 
       expect(result, isA<Success>());
     });
@@ -39,10 +41,11 @@ void main() {
       const exception = NetworkExceptions.unexpectedError();
 
       when(mockRepository.submitSurvey(
-        submitSurveyRequest: submitSurveyRequest,
+        surveyId: input.surveyId,
+        questions: input.questions,
       )).thenAnswer((_) => Future.error(exception));
 
-      final result = await useCase.call(submitSurveyRequest);
+      final result = await useCase.call(input);
 
       expect(result, isA<Failed>());
       expect((result as Failed).exception.actualException, exception);

--- a/test/usecase/submit_survey_use_case_test.dart
+++ b/test/usecase/submit_survey_use_case_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:survey_flutter_ic/api/exception/network_exceptions.dart';
+import 'package:survey_flutter_ic/api/request/submit_survey_request.dart';
+import 'package:survey_flutter_ic/usecase/base/base_use_case.dart';
+import 'package:survey_flutter_ic/usecase/submit_survey_use_case.dart';
+
+import '../mocks/generate_mocks.mocks.dart';
+
+void main() {
+  group('SubmitSurveyUseCase', () {
+    late MockSurveyRepository mockRepository;
+    late SubmitSurveyUseCase useCase;
+
+    setUp(() {
+      mockRepository = MockSurveyRepository();
+      useCase = SubmitSurveyUseCase(mockRepository);
+    });
+
+    final submitSurveyRequest = SubmitSurveyRequest(
+      surveyId: 'survey_id',
+      questions: [],
+    );
+
+    test(
+        'When calling SubmitSurvey successfully, it returns the result Success',
+        () async {
+      when(
+        mockRepository.submitSurvey(submitSurveyRequest: submitSurveyRequest),
+      ).thenAnswer((_) async => (null));
+
+      final result = await useCase.call(submitSurveyRequest);
+
+      expect(result, isA<Success>());
+    });
+
+    test('When calling SubmitSurvey failed, it returns the result Failed',
+        () async {
+      const exception = NetworkExceptions.unexpectedError();
+
+      when(mockRepository.submitSurvey(
+        submitSurveyRequest: submitSurveyRequest,
+      )).thenAnswer((_) => Future.error(exception));
+
+      final result = await useCase.call(submitSurveyRequest);
+
+      expect(result, isA<Failed>());
+      expect((result as Failed).exception.actualException, exception);
+    });
+  });
+}


### PR DESCRIPTION
#23

## What happened 👀


Call `POST /api/v1/responses` endpoint with the following body:

```
{
  "survey_id": "{{survey-id}}",
  "questions": [
    {{question-id-with-answers}},
    ...
  ]
}
```

For `question-id-with-answers`, there are two possible types of this data structure:

1. With ID
```json
{
"id": "{{question-id}}",
"answers": [
 {
   "id": "{{answer-id}}"
 }
]
}
```

2. With ID and Answer
```json
{
"id": "{{question-id}}",
"answers": [
 {
   "id": "{{answer-id}}",
   "answer": "{{answer}}"
 }
]
}
```

## Insight 📝

- Create `SubmitSurveyAnswerRequest`, `SubmitSurveyQuestionRequest`, and `SubmitSurveyRequest`.
- Create `SubmitSurveyAnswerModel`, and `SubmitSurveyQuestionModel`.
- Create `SubmitSurveyUseCase`.
- Add method `submitSurvey` in `survey_repository`.

## Proof Of Work 📹

```
flutter: *** Request ***
flutter: uri: https://survey-api.nimblehq.co/api/v1/responses
flutter: method: POST
flutter: responseType: ResponseType.json
flutter: followRedirects: true
flutter: persistentConnection: true
flutter: connectTimeout: 0:00:03.000000
flutter: sendTimeout: null
flutter: receiveTimeout: 0:00:05.000000
flutter: receiveDataWhenStatusError: true
flutter: extra: {}
flutter: headers:
flutter:  Content-Type: application/json; charset=utf-8
flutter:  Authorization: Bearer mR97XGClZCnjCkbQkOmgZii2bQwzLOa4Z9abEAvUaBg
flutter:  content-length: 227
flutter: data:
flutter: {survey_id: d5de6a8f8f5f1cfe51bc, questions: [Instance of 'SubmitSurveyQuestionRequest', Instance of 'SubmitSurveyQuestionRequest']}
flutter:
flutter: *** Response ***
flutter: uri: https://survey-api.nimblehq.co/api/v1/responses
flutter: statusCode: 201
flutter: headers:
flutter:  connection: keep-alive
flutter:  cache-control: max-age=0, private, must-revalidate
flutter:  date: Tue, 06 Jun 2023 12:37:09 GMT
flutter:  vary: Accept-Encoding, Origin
flutter:  content-encoding: gzip
flutter:  referrer-policy: strict-origin-when-cross-origin
flutter:  report-to: {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=maF9DDjjBirLYVne5dVET0nMshzNMZHX7CeYxU%2F3O7M44de6pR6vyHKWKtvh%2BVJx33Zym6t6GkN2hZof5Kl2PJeF%2FXVm8VbgMaFvvvcZkUAF1JrrNZtU87IN5IHcu1vI24tr5kLTZjZx"}],"group":"cf-nel","max_age":604800}
flutter:  cf-cache-status: DYNAMIC
flutter:  x-permitted-cross-domain-policies: none
flutter:  content-type: application/json; charset=utf-8
flutter:  x-xss-protection: 0
flutter:  server: cloudflare
flutter:  x-request-id: b3795f5b-f251-4f0b-b384-77f3e3998248
flutter:  alt-svc: h3=":443"; ma=86400
flutter:  content-length: 28
flutter:  nel: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
flutter:  x-download-options: noopen
flutter:  cf-ray: 7d30b47d49e226f5-BKK
flutter:  x-runtime: 0.016270
flutter:  etag: W/"9c9270275739c7283745bb5c0f381983"
flutter:  via: 1.1 vegur
flutter:  x-frame-options: SAMEORIGIN
flutter:  x-content-type-options: nosniff
flutter: Response Text:
flutter: {}
```
