### PR TITLE
[#24] [Part 2/2] [Integrate] As a user, I can submit my survey response

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,5 +1,6 @@
 {
-  "hello": "Hello!",
+  "alert_dialog_button_action_ok": "Ok",
+  "alert_dialog_title_error": "Error",
 
   "home_today": "Today",
 

--- a/lib/navigation/route.dart
+++ b/lib/navigation/route.dart
@@ -4,6 +4,7 @@ import 'package:survey_flutter_ic/model/survey_model.dart';
 import 'package:survey_flutter_ic/ui/home/home_screen.dart';
 import 'package:survey_flutter_ic/ui/signin/sign_in_screen.dart';
 import 'package:survey_flutter_ic/ui/splash/splash_screen.dart';
+import 'package:survey_flutter_ic/ui/survey_completion/survey_completion_screen.dart';
 import 'package:survey_flutter_ic/ui/survey_detail/survey_detail_screen.dart';
 import 'package:survey_flutter_ic/ui/survey_question/survey_questions_screen.dart';
 
@@ -14,7 +15,8 @@ enum RoutePath {
   home('/home', 'home'),
   signIn('/sign_in', 'sign_in'),
   surveyDetail('survey_detail', 'survey_detail'),
-  surveyQuestions('survey_questions/:$surveyIdKey', 'survey_questions');
+  surveyQuestions('survey_questions/:$surveyIdKey', 'survey_questions'),
+  completion('completion', 'completion');
 
   const RoutePath(this.path, this.name);
 
@@ -60,6 +62,11 @@ class AppRouter {
                 builder: (_, state) => SurveyQuestionsScreen(
                   surveyId: (state.params[surveyIdKey] as String),
                 ),
+              ),
+              GoRoute(
+                name: RoutePath.completion.name,
+                path: RoutePath.completion.path,
+                builder: (_, __) => const SurveyCompletionScreen(),
               ),
             ],
           ),

--- a/lib/ui/survey_completion/survey_completion_screen.dart
+++ b/lib/ui/survey_completion/survey_completion_screen.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:survey_flutter_ic/theme/dimens.dart';
+
+class SurveyCompletionScreen extends ConsumerStatefulWidget {
+  const SurveyCompletionScreen({super.key});
+
+  @override
+  ConsumerState<SurveyCompletionScreen> createState() =>
+      _SurveyCompletionState();
+}
+
+class _SurveyCompletionState extends ConsumerState<SurveyCompletionScreen> {
+  @override
+  Widget build(BuildContext context) {
+    // TODO: Update widget
+    return const Scaffold(
+      body: Center(
+        child: Text(
+          'Completion Screen',
+          style: TextStyle(
+            color: Colors.white,
+            fontSize: fontSize34,
+            fontWeight: FontWeight.w400,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/survey_question/survey_questions_screen.dart
+++ b/lib/ui/survey_question/survey_questions_screen.dart
@@ -4,15 +4,16 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:survey_flutter_ic/extension/context_extension.dart';
-import 'package:survey_flutter_ic/extension/toast_extension.dart';
 import 'package:survey_flutter_ic/gen/assets.gen.dart';
 import 'package:survey_flutter_ic/model/survey_question_model.dart';
+import 'package:survey_flutter_ic/navigation/route.dart';
 import 'package:survey_flutter_ic/theme/dimens.dart';
 import 'package:survey_flutter_ic/ui/survey_question/survey_question_item.dart';
 import 'package:survey_flutter_ic/ui/survey_question/survey_questions_view_model.dart';
 import 'package:survey_flutter_ic/ui/survey_question/survey_questions_view_state.dart';
 import 'package:survey_flutter_ic/widget/circle_next_button.dart';
 import 'package:survey_flutter_ic/widget/flat_button_text.dart';
+import 'package:survey_flutter_ic/widget/survey_alert_dialog.dart';
 
 class SurveyQuestionsScreen extends ConsumerStatefulWidget {
   final String surveyId;
@@ -46,7 +47,20 @@ class _SurveyQuestionsState extends ConsumerState<SurveyQuestionsScreen> {
     ref.listen<SurveyQuestionsViewState>(surveyQuestionsViewModelProvider,
         (_, state) {
       state.maybeWhen(
-        error: (message) => showToastMessage(message),
+        navigateToCompletionScreen: () {
+          context.goNamed(RoutePath.completion.name);
+        },
+        error: (message) {
+          showDialog(
+            context: context,
+            builder: (context) => SurveyAlertDialog(
+              title: context.localization.alert_dialog_title_error,
+              description: message,
+              positiveActionText:
+                  context.localization.alert_dialog_button_action_ok,
+            ),
+          );
+        },
         orElse: () {},
       );
     });

--- a/lib/ui/survey_question/survey_questions_view_model.dart
+++ b/lib/ui/survey_question/survey_questions_view_model.dart
@@ -116,9 +116,11 @@ class SurveyQuestionsViewModel extends StateNotifier<SurveyQuestionsViewState> {
       _isLoading.add(false);
     }).listen((result) {
       if (result is Success<void>) {
-        // TODO: navigate to thanks screen in part 2
+        _submitSurveyQuestions.clear();
+        state = const SurveyQuestionsViewState.navigateToCompletionScreen();
       } else {
-        // TODO: show dialog in part 2
+        final error = result as Failed<void>;
+        state = SurveyQuestionsViewState.error(error.getErrorMessage());
       }
     });
   }

--- a/lib/ui/survey_question/survey_questions_view_state.dart
+++ b/lib/ui/survey_question/survey_questions_view_state.dart
@@ -6,5 +6,8 @@ part 'survey_questions_view_state.freezed.dart';
 class SurveyQuestionsViewState with _$SurveyQuestionsViewState {
   const factory SurveyQuestionsViewState.init() = _Init;
 
+  const factory SurveyQuestionsViewState.navigateToCompletionScreen() =
+      _NavigateToCompletionScreen;
+
   const factory SurveyQuestionsViewState.error(String message) = _Error;
 }

--- a/lib/widget/survey_alert_dialog.dart
+++ b/lib/widget/survey_alert_dialog.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:survey_flutter_ic/theme/dimens.dart';
+
+class SurveyAlertDialog extends StatelessWidget {
+  final String title;
+  final String description;
+  final String positiveActionText;
+
+  const SurveyAlertDialog({
+    super.key,
+    required this.title,
+    required this.description,
+    required this.positiveActionText,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(
+        title,
+        style: const TextStyle(
+          color: Colors.black,
+          fontSize: fontSize17,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+      content: Text(
+        description,
+        style: const TextStyle(
+          color: Colors.black,
+          fontSize: fontSize17,
+          fontWeight: FontWeight.normal,
+        ),
+      ),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () {
+            context.pop(false);
+          },
+          child: Text(
+            positiveActionText,
+            style: const TextStyle(
+              color: Colors.blue,
+              fontSize: fontSize17,
+              fontWeight: FontWeight.normal,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/test/ui/survey_question/survey_questions_view_model_test.dart
+++ b/test/ui/survey_question/survey_questions_view_model_test.dart
@@ -123,5 +123,34 @@ void main() {
           .read(surveyQuestionsViewModelProvider.notifier)
           .submitSurvey("surveyId");
     });
+
+    test(
+        'When calling SubmitSurvey successfully, it returns navigateToCompletionScreen state',
+        () {
+      expect(
+        viewModel.stream,
+        emitsThrough(
+          const SurveyQuestionsViewState.navigateToCompletionScreen(),
+        ),
+      );
+
+      container
+          .read(surveyQuestionsViewModelProvider.notifier)
+          .submitSurvey("surveyId");
+    });
+
+    test('When calling SubmitSurvey failed, it returns the error state', () {
+      when(mockSubmitSurveyUseCase.call(any)).thenAnswer((_) async => Failed(
+          UseCaseException(const NetworkExceptions.defaultError("Error"))));
+
+      expect(
+        viewModel.stream,
+        emitsThrough(const SurveyQuestionsViewState.error("Error")),
+      );
+
+      container
+          .read(surveyQuestionsViewModelProvider.notifier)
+          .submitSurvey("surveyId");
+    });
   });
 }


### PR DESCRIPTION
#24

## What happened 👀

Upon tapping the Submit button, perform the Submit Survey Response request with the survey id and the user's answers.
- If the request is successful,
    - Navigate the Thanks screen.
- Otherwise, display the error message on a modal alert dialog with an OK button
    - Selecting the OK button does nothing. DO NOT dismiss the screen so that the user can retry the submission.
## Insight 📝

- Create a `SurveyCompletionScreen`. 
- Create a `SurveyAlertDialog` widget.

Please note: The `Integration test` will be handled separately in another ticket/pull request.

Reference: [part 1/2](https://github.com/Wadeewee/survey-flutter-ic-pooh/pull/66).

## Proof Of Work 📹

- When calling `SubmitSurvey` successfully:

https://github.com/Wadeewee/survey-flutter-ic-pooh/assets/28002315/70346dd0-1325-4d79-9883-a1e9f3dc5736

- When calling `SubmitSurvey` failed:

https://github.com/Wadeewee/survey-flutter-ic-pooh/assets/28002315/e6ece83a-67ed-4f06-9c66-3486f68f5b94

