### PR TITLE
[#27] [Integrate] As a user, I can quit the survey

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,6 +1,9 @@
 {
+  "alert_dialog_button_action_cancel": "Cancel",
   "alert_dialog_button_action_ok": "Ok",
+  "alert_dialog_button_action_yes": "Yes",
   "alert_dialog_title_error": "Error",
+  "alert_dialog_title_warning": "Warning!",
 
   "home_today": "Today",
 
@@ -12,6 +15,8 @@
 
   "survey_question_nps_lowest_description": "Not at all Likely",
   "survey_question_nps_highest_description": "Extremely Likely",
+
+  "survey_question_quit_confirmation_description": "Are you sure you want to quit the survey?",
 
   "survey_question_submit_button": "Submit",
 

--- a/lib/ui/survey_question/survey_questions_screen.dart
+++ b/lib/ui/survey_question/survey_questions_screen.dart
@@ -53,7 +53,7 @@ class _SurveyQuestionsState extends ConsumerState<SurveyQuestionsScreen> {
         error: (message) {
           showDialog(
             context: context,
-            builder: (context) => SurveyAlertDialog(
+            builder: (_) => SurveyAlertDialog(
               title: context.localization.alert_dialog_title_error,
               description: message,
               positiveActionText:
@@ -128,7 +128,22 @@ class _SurveyQuestionsState extends ConsumerState<SurveyQuestionsScreen> {
         icon: Assets.images.icClose.svg(),
         padding: EdgeInsets.zero,
         constraints: const BoxConstraints(),
-        onPressed: () => context.pop(),
+        onPressed: () {
+          context.hideKeyboard();
+          showDialog(
+            context: context,
+            builder: (_) => SurveyAlertDialog(
+              title: context.localization.alert_dialog_title_warning,
+              description: context
+                  .localization.survey_question_quit_confirmation_description,
+              positiveActionText:
+                  context.localization.alert_dialog_button_action_yes,
+              negativeActionText:
+                  context.localization.alert_dialog_button_action_cancel,
+              onPositiveActionPressed: () => context.pop(),
+            ),
+          );
+        },
       ),
     );
   }

--- a/lib/widget/survey_alert_dialog.dart
+++ b/lib/widget/survey_alert_dialog.dart
@@ -6,12 +6,16 @@ class SurveyAlertDialog extends StatelessWidget {
   final String title;
   final String description;
   final String positiveActionText;
+  final String? negativeActionText;
+  final VoidCallback? onPositiveActionPressed;
 
   const SurveyAlertDialog({
     super.key,
     required this.title,
     required this.description,
     required this.positiveActionText,
+    this.negativeActionText,
+    this.onPositiveActionPressed,
   });
 
   @override
@@ -34,9 +38,22 @@ class SurveyAlertDialog extends StatelessWidget {
         ),
       ),
       actions: <Widget>[
+        if (negativeActionText != null)
+          TextButton(
+            onPressed: () => context.pop(false),
+            child: Text(
+              negativeActionText ?? '',
+              style: const TextStyle(
+                color: Colors.blue,
+                fontSize: fontSize17,
+                fontWeight: FontWeight.normal,
+              ),
+            ),
+          ),
         TextButton(
           onPressed: () {
             context.pop(false);
+            onPositiveActionPressed?.call();
           },
           child: Text(
             positiveActionText,


### PR DESCRIPTION
#27

## What happened 👀

Upon tapping the Dismiss button,
- If a user has replied to at least 1 question of the survey, prompt a modal dialog with the following content:
    - Title - Warning
    - Message - Are you sure you want to quit the survey?
    - Yes action - Yes
        - Selecting Yes dismisses the screen
    - Cancel action - Cancel
        - Selecting Cancel does nothing

## Insight 📝

- Add the `negative` button on the SurveyAlertDialog.
- Add the function callback for the `positive` button on the SurveyAlertDialog.

## Proof Of Work 📹

https://github.com/Wadeewee/survey-flutter-ic-pooh/assets/28002315/48630266-8e6d-45e7-b8ba-f080e0f33e99
