### PR TITLE
[#29] [Backend] As a user, I can sign out

### DIFF
--- a/lib/api/repository/auth_repository.dart
+++ b/lib/api/repository/auth_repository.dart
@@ -1,4 +1,5 @@
 import 'package:injectable/injectable.dart';
+import 'package:survey_flutter_ic/api/request/sign_out_request.dart';
 
 import '../../env.dart';
 import '../../model/auth_model.dart';
@@ -14,6 +15,10 @@ abstract class AuthRepository {
   Future<AuthModel> signIn({
     required String email,
     required String password,
+  });
+
+  Future<void> signOut({
+    required String token,
   });
 
   Future<AuthModel> refreshToken({
@@ -43,6 +48,21 @@ class AuthRepositoryImpl extends AuthRepository {
         ),
       );
       return AuthModel.fromResponse(response);
+    } catch (exception) {
+      throw NetworkExceptions.fromDioException(exception);
+    }
+  }
+
+  @override
+  Future<void> signOut({required String token}) async {
+    try {
+      await _authService.signOut(
+        SignOutRequest(
+          token: token,
+          clientId: Env.clientId,
+          clientSecret: Env.clientSecret,
+        ),
+      );
     } catch (exception) {
       throw NetworkExceptions.fromDioException(exception);
     }

--- a/lib/api/request/sign_out_request.dart
+++ b/lib/api/request/sign_out_request.dart
@@ -1,0 +1,21 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'sign_out_request.g.dart';
+
+@JsonSerializable()
+class SignOutRequest {
+  final String token;
+  final String clientId;
+  final String clientSecret;
+
+  SignOutRequest({
+    required this.token,
+    required this.clientId,
+    required this.clientSecret,
+  });
+
+  factory SignOutRequest.fromJson(Map<String, dynamic> json) =>
+      _$SignOutRequestFromJson(json);
+
+  Map<String, dynamic> toJson() => _$SignOutRequestToJson(this);
+}

--- a/lib/api/service/auth_service.dart
+++ b/lib/api/service/auth_service.dart
@@ -1,5 +1,6 @@
 import 'package:dio/dio.dart';
 import 'package:retrofit/http.dart';
+import 'package:survey_flutter_ic/api/request/sign_out_request.dart';
 import '../request/refresh_token_request.dart';
 import '../request/sign_in_request.dart';
 import '../response/auth_response.dart';
@@ -9,6 +10,10 @@ part 'auth_service.g.dart';
 abstract class AuthService {
   Future<AuthResponse> signIn(
     @Body() SignInRequest body,
+  );
+
+  Future<void> signOut(
+    @Body() SignOutRequest body,
   );
 
   Future<AuthResponse> refreshToken(
@@ -24,6 +29,12 @@ abstract class AuthServiceImpl extends AuthService {
   @POST('/api/v1/oauth/token')
   Future<AuthResponse> signIn(
     @Body() SignInRequest body,
+  );
+
+  @override
+  @POST('/api/v1/oauth/revoke')
+  Future<void> signOut(
+    @Body() SignOutRequest body,
   );
 
   @override

--- a/lib/usecase/sign_out_use_case.dart
+++ b/lib/usecase/sign_out_use_case.dart
@@ -1,0 +1,30 @@
+import 'dart:async';
+
+import 'package:injectable/injectable.dart';
+import 'package:survey_flutter_ic/api/exception/network_exceptions.dart';
+import 'package:survey_flutter_ic/api/persistence/auth_persistence.dart';
+import 'package:survey_flutter_ic/api/repository/auth_repository.dart';
+import 'package:survey_flutter_ic/usecase/base/base_use_case.dart';
+
+@Injectable()
+class SignOutUseCase extends NoParamsUseCase<void> {
+  final AuthRepository _repository;
+  final AuthPersistence _persistence;
+
+  const SignOutUseCase(
+    this._repository,
+    this._persistence,
+  );
+
+  @override
+  Future<Result<void>> call() async {
+    final accessToken = await _persistence.accessToken ?? '';
+
+    return _repository
+        .signOut(token: accessToken)
+        // ignore: unnecessary_cast
+        .then((value) => Success(value) as Result<void>)
+        .onError<NetworkExceptions>(
+            (exception, stackTrace) => Failed(UseCaseException(exception)));
+  }
+}

--- a/test/api/repository/auth_repository_test.dart
+++ b/test/api/repository/auth_repository_test.dart
@@ -17,6 +17,14 @@ void main() {
     late MockAuthService mockAuthService;
     late AuthRepository repository;
 
+    final response = AuthResponse(
+      accessToken: 'accessToken',
+      tokenType: 'tokenType',
+      expiresIn: 0,
+      refreshToken: 'refreshToken',
+      createdAt: 0,
+    );
+
     setUp(() {
       mockAuthService = MockAuthService();
       repository = AuthRepositoryImpl(mockAuthService);
@@ -25,14 +33,6 @@ void main() {
     test(
         'When calling signIn successfully, it emits the corresponding AuthModel',
         () async {
-      final response = AuthResponse(
-        accessToken: 'accessToken',
-        tokenType: 'tokenType',
-        expiresIn: 0,
-        refreshToken: 'refreshToken',
-        createdAt: 0,
-      );
-
       when(mockAuthService.signIn(any)).thenAnswer((_) async => response);
 
       final result = await repository.signIn(
@@ -48,6 +48,45 @@ void main() {
       when(mockAuthService.signIn(any)).thenThrow(MockDioError());
 
       result() => repository.signIn(email: 'email', password: 'password');
+
+      expect(result, throwsA(isA<NetworkExceptions>()));
+    });
+
+    test('When calling signOut successfully, it returns empty result',
+        () async {
+      when(mockAuthService.signOut(any)).thenAnswer((_) async => (null));
+
+      result() => repository.signOut(token: 'token');
+
+      expect(() async => result, isA<void>());
+    });
+
+    test('When calling signOut failed, it returns NetworkExceptions error',
+        () async {
+      when(mockAuthService.signOut(any)).thenThrow(MockDioError());
+
+      result() => repository.signOut(token: 'token');
+
+      expect(result, throwsA(isA<NetworkExceptions>()));
+    });
+
+    test(
+        'When calling refreshToken successfully, it emits the corresponding AuthModel',
+        () async {
+      when(mockAuthService.refreshToken(any)).thenAnswer((_) async => response);
+
+      final result = await repository.refreshToken(
+        refreshToken: 'refreshToken',
+      );
+
+      expect(result, AuthModel.fromResponse(response));
+    });
+
+    test('When calling refreshToken failed, it returns NetworkExceptions error',
+        () async {
+      when(mockAuthService.refreshToken(any)).thenThrow(MockDioError());
+
+      result() => repository.refreshToken(refreshToken: 'refreshToken');
 
       expect(result, throwsA(isA<NetworkExceptions>()));
     });

--- a/test/usecase/sign_out_use_case_test.dart
+++ b/test/usecase/sign_out_use_case_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:survey_flutter_ic/api/exception/network_exceptions.dart';
+import 'package:survey_flutter_ic/usecase/base/base_use_case.dart';
+import 'package:survey_flutter_ic/usecase/sign_out_use_case.dart';
+
+import '../mocks/generate_mocks.mocks.dart';
+
+void main() {
+  group('SignOutUseCase', () {
+    late MockAuthRepository mockRepository;
+    late MockAuthPersistence mockPersistence;
+    late SignOutUseCase useCase;
+
+    setUp(() {
+      mockRepository = MockAuthRepository();
+      mockPersistence = MockAuthPersistence();
+      useCase = SignOutUseCase(mockRepository, mockPersistence);
+
+      when(mockPersistence.accessToken).thenAnswer((_) async => 'accessToken');
+    });
+
+    test('When calling SignOut successfully, it returns the result Success',
+        () async {
+      when(mockRepository.signOut(token: 'accessToken'))
+          .thenAnswer((_) async => (null));
+
+      final result = await useCase.call();
+
+      expect(result, isA<Success>());
+    });
+
+    test('When calling SignOut failed, it returns the result Failed', () async {
+      const exception = NetworkExceptions.unexpectedError();
+      when(mockRepository.signOut(token: 'accessToken'))
+          .thenAnswer((_) => Future.error(exception));
+
+      final result = await useCase.call();
+
+      expect(result, isA<Failed>());
+      expect((result as Failed).exception.actualException, exception);
+    });
+  });
+}


### PR DESCRIPTION
#29

## What happened 👀

Call `POST /api/v1/oauth/revoke` to sign out with the following body:
```json
{
  "token": "{{user_access_token}}",
  "client_id": "{{client_id}}",
  "client_secret": "{{client_secret}}"
}
```

## Insight 📝

- Create a `SignOutRequest` model.
- Add a method `signOut` in `AuthService` and `AuthRepository`.
- Create a `SignOutUseCase`.

## Proof Of Work 📹

```
flutter: *** Request ***
flutter: uri: https://survey-api.nimblehq.co/api/v1/oauth/revoke
flutter: method: POST
flutter: responseType: ResponseType.json
flutter: followRedirects: true
flutter: persistentConnection: true
flutter: connectTimeout: 0:00:03.000000
flutter: sendTimeout: null
flutter: receiveTimeout: 0:00:05.000000
flutter: receiveDataWhenStatusError: true
flutter: extra: {}
flutter: headers:
flutter:  Content-Type: application/json; charset=utf-8
flutter:  Authorization: 3Ao9avmotQCR3xrBGhUwGTH9LYOwBtoQTUz8PUT5Jz0
flutter: data:
flutter: {token: 3Ao9avmotQCR3xrBGhUwGTH9LYOwBtoQTUz8PUT5Jz0, client_id: 6GbE8dhoz519l2N_F99StqoOs6Tcmm1rXgda4q__rIw, client_secret: _ayfIm7BeUAhx2W1OUqi20fwO3uNxfo1QstyKlFCgHw}
flutter:
flutter: *** Response ***
flutter: uri: https://survey-api.nimblehq.co/api/v1/oauth/revoke
flutter: statusCode: 200
flutter: headers:
flutter:  connection: keep-alive
flutter:  cache-control: max-age=0, private, must-revalidate
flutter:  date: Mon, 12 Jun 2023 07:50:51 GMT
flutter:  vary: Accept-Encoding, Origin
flutter:  content-encoding: gzip
flutter:  referrer-policy: strict-origin-when-cross-origin
flutter:  report-to: {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=WnGOufYg%2BE4zyVk4g6C%2FGJ2ronCFwC8Dn6JiH9rTDFElbuxOt1p%2F8LWMFSvKTBs7aD9ds0tFc4BIqRDbWZO9%2FYl21LSQfX0PVc8qUN5S1zOMQNfb2I3D0b%2BKDDLdI6y6BYN2WfbSRjWE"}],"group":"cf-nel","max_age":604800}
flutter:  cf-cache-status: DYNAMIC
flutter:  x-permitted-cross-domain-policies: none
flutter:  content-type: application/json; charset=utf-8
flutter:  x-xss-protection: 0
flutter:  server: cloudflare
flutter:  x-request-id: a428106b-9776-41d1-834e-82d751205e75
flutter:  alt-svc: h3=":443"; ma=86400
flutter:  content-length: 28
flutter:  nel: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
flutter:  x-download-options: noopen
flutter:  cf-ray: 7d6081549ebcee29-BKK
flutter:  x-runtime: 0.015601
flutter:  etag: W/"5eeb07ec750b1012d0e051a821acd889"
flutter:  via: 1.1 vegur
flutter:  x-frame-options: SAMEORIGIN
flutter:  x-content-type-options: nosniff
flutter: Response Text:
flutter: {}
```